### PR TITLE
fix(core): reduce sqlite "database is locked" errors

### DIFF
--- a/packages/core/src/db/mod.ts
+++ b/packages/core/src/db/mod.ts
@@ -58,6 +58,7 @@ class Database {
       throw new Error(`Version mismatch: Forager app version is ${this.#torm.migrations.application_version()}, while the database version is currently ${init_info.current_version}. Consider turning on automatic migrations, or manually migrating the database`)
     }
     this.#torm.driver.exec(`PRAGMA journal_mode=WAL`)
+    this.#torm.driver.exec(`PRAGMA busy_timeout=${this.#ctx.config.database.busy_timeout}`)
     return init_info
   }
 
@@ -72,7 +73,7 @@ class Database {
 
   public transaction_sync = <T>(fn: () => T) => (): T => {
     try {
-      this.#torm.driver.exec('BEGIN TRANSACTION')
+      this.#torm.driver.exec('BEGIN IMMEDIATE')
       const result = fn()
       this.#torm.driver.exec('COMMIT')
       return result
@@ -84,12 +85,11 @@ class Database {
 
   public transaction_async = <T>(fn: () => Promise<T>) => async (): Promise<T> => {
     try {
-      this.#torm.driver.exec('BEGIN TRANSACTION')
+      this.#torm.driver.exec('BEGIN IMMEDIATE')
       const result = await fn()
       this.#torm.driver.exec('COMMIT')
       return result
     } catch(e) {
-      console.log(e)
       this.#torm.driver.exec('ROLLBACK')
       throw e
     }

--- a/packages/core/src/inputs/forager_config_inputs.ts
+++ b/packages/core/src/inputs/forager_config_inputs.ts
@@ -25,6 +25,9 @@ export const ForagerConfig = z.object({
 
     /** Enable backups during migrations (saved in <database.folder>/backups/) */
     backups: z.boolean().default(true),
+
+    /** How long (in milliseconds) to wait when the database is locked by another process before throwing an error. Relevant when running multiple processes (e.g. web GUI and CLI ingest) against the same database. Set to 0 to fail immediately. */
+    busy_timeout: z.number().int().min(0).default(5000),
   }).strict(),
 
   logger: z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Set SQLite `busy_timeout` and use `BEGIN IMMEDIATE` to prevent "database is locked" errors during concurrent database access.

<div><a href="https://cursor.com/agents/bc-0d58d698-c91d-48c1-83a1-2dd2d09a6b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d58d698-c91d-48c1-83a1-2dd2d09a6b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->