### PR TITLE
fix(core): make tag cleanup aware of alias/parent rules and hide zero-count tags

### DIFF
--- a/packages/core/src/actions/tag_actions.ts
+++ b/packages/core/src/actions/tag_actions.ts
@@ -95,6 +95,7 @@ class TagActions extends Actions {
       cursor: parsed.cursor,
       tag_match: parsed.query.tag_match,
       contextual_query: contextual_query,
+      include_zero_reference_count: parsed.include_zero_reference_count,
     })
 
     const results: TagSearchResultItem[] = paginated.results.map(tag => {

--- a/packages/core/src/actions/tag_actions.ts
+++ b/packages/core/src/actions/tag_actions.ts
@@ -95,7 +95,7 @@ class TagActions extends Actions {
       cursor: parsed.cursor,
       tag_match: parsed.query.tag_match,
       contextual_query: contextual_query,
-      include_zero_reference_count: parsed.include_zero_reference_count,
+      include_unreferenced_tags: parsed.include_unreferenced_tags,
     })
 
     const results: TagSearchResultItem[] = paginated.results.map(tag => {

--- a/packages/core/src/inputs/tag_search_input.ts
+++ b/packages/core/src/inputs/tag_search_input.ts
@@ -13,6 +13,7 @@ export const TagSearch  = PaginatedQuery.extend({
       return {...q}
     }),
   contextual_query: MediaReferenceQuery,
+  include_zero_reference_count: z.boolean().optional().default(false),
   limit: z.number().optional().default(10),
   sort_by: z.enum(['created_at', 'updated_at', 'media_reference_count', 'unread_media_reference_count']).default('media_reference_count'),
   order: z.enum(['desc', 'asc']).default('desc'),

--- a/packages/core/src/inputs/tag_search_input.ts
+++ b/packages/core/src/inputs/tag_search_input.ts
@@ -13,7 +13,7 @@ export const TagSearch  = PaginatedQuery.extend({
       return {...q}
     }),
   contextual_query: MediaReferenceQuery,
-  include_zero_reference_count: z.boolean().optional().default(false),
+  include_unreferenced_tags: z.boolean().optional().default(false),
   limit: z.number().optional().default(10),
   sort_by: z.enum(['created_at', 'updated_at', 'media_reference_count', 'unread_media_reference_count']).default('media_reference_count'),
   order: z.enum(['desc', 'asc']).default('desc'),

--- a/packages/core/src/models/tag.ts
+++ b/packages/core/src/models/tag.ts
@@ -90,7 +90,11 @@ class Tag extends Model {
 
   #delete_by_count = this.query`
     DELETE FROM tag
-    WHERE tag.media_reference_count = 0`
+    WHERE tag.media_reference_count = 0
+      AND tag.slug NOT IN (SELECT alias_tag_slug FROM tag_alias)
+      AND tag.slug NOT IN (SELECT alias_for_tag_slug FROM tag_alias)
+      AND tag.slug NOT IN (SELECT child_tag_slug FROM tag_parent)
+      AND tag.slug NOT IN (SELECT parent_tag_slug FROM tag_parent)`
 
   #select_one_impl(params: {
     id?: number
@@ -142,6 +146,7 @@ class Tag extends Model {
       group: string | undefined
     } | undefined
     contextual_query: SelectManyFilters | undefined
+    include_zero_reference_count?: boolean
   }): PaginatedResult<TagJoin> {
     if (params.cursor !== undefined) {
       throw new Error('unimplemented')
@@ -179,6 +184,10 @@ class Tag extends Model {
       } else {
         tags_sql_builder.add_where_clause(`tag.name GLOB '${name}' AND tag_group.name GLOB '${group}'`)
       }
+    }
+
+    if (!params.include_zero_reference_count) {
+      tags_sql_builder.add_where_clause(`tag.media_reference_count > 0`)
     }
 
     let results: TagJoin[]

--- a/packages/core/src/models/tag.ts
+++ b/packages/core/src/models/tag.ts
@@ -146,7 +146,7 @@ class Tag extends Model {
       group: string | undefined
     } | undefined
     contextual_query: SelectManyFilters | undefined
-    include_zero_reference_count?: boolean
+    include_unreferenced_tags?: boolean
   }): PaginatedResult<TagJoin> {
     if (params.cursor !== undefined) {
       throw new Error('unimplemented')
@@ -186,7 +186,7 @@ class Tag extends Model {
       }
     }
 
-    if (!params.include_zero_reference_count) {
+    if (!params.include_unreferenced_tags) {
       tags_sql_builder.add_where_clause(`tag.media_reference_count > 0`)
     }
 

--- a/packages/core/test/tag.test.ts
+++ b/packages/core/test/tag.test.ts
@@ -157,8 +157,8 @@ test('tag actions', async (ctx) => {
     ctx.assert.tag_search_result(forager.tag.search(), assert_tags_after)
     doodle = forager.media.update(doodle.media_reference.id, {}, {replace: []})
     ctx.assert.list_partial(doodle.tags, [])
-    // now observe that the tag _does_ exist
-    ctx.assert.tag_search_result(forager.tag.search(), {
+    // now observe that the tag _does_ exist when we include zero-reference-count tags
+    ctx.assert.tag_search_result(forager.tag.search({include_zero_reference_count: true}), {
       total: 6,
       results: [
         {group: '', name: 'wallpaper', media_reference_count: 2},
@@ -169,11 +169,34 @@ test('tag actions', async (ctx) => {
         {group: '', name: 'foobar', media_reference_count: 0},
       ]
     })
+    // default tag.search hides zero-reference-count tags
+    ctx.assert.tag_search_result(forager.tag.search(), {
+      total: 5,
+      results: [
+        {group: '', name: 'wallpaper', media_reference_count: 2},
+        {group: 'genre', name: 'cartoon'},
+        {group: 'colors', name: 'black'},
+        {group: '', name: 'generated'},
+        {group: 'genre', name: 'procedural_generation'},
+      ]
+    })
   })
 
   await ctx.subtest(`tag sort`, async () => {
-    // default sort is by 'media_reference_count'
+    // default sort is by 'media_reference_count', zero-count tags hidden by default
     ctx.assert.tag_search_result(forager.tag.search({sort_by: 'media_reference_count'}), {
+      total: 5,
+      results: [
+        {group: '', name: 'wallpaper', media_reference_count: 2},
+        {group: 'genre', name: 'cartoon'},
+        {group: 'colors', name: 'black'},
+        {group: '', name: 'generated'},
+        {group: 'genre', name: 'procedural_generation'},
+      ]
+    })
+
+    // with include_zero_reference_count, foobar shows up
+    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'media_reference_count', include_zero_reference_count: true}), {
       total: 6,
       results: [
         {group: '', name: 'wallpaper', media_reference_count: 2},
@@ -189,7 +212,7 @@ test('tag actions', async (ctx) => {
     await ctx.timeout(10)
     forager.media.update(doodle.media_reference.id, {}, {add: ['genre:cartoon']})
 
-    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'updated_at'}), {
+    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'updated_at', include_zero_reference_count: true}), {
       results: [
         {name: 'cartoon', media_reference_count: 2},
         {group: '', name: 'foobar', media_reference_count: 0},
@@ -376,10 +399,9 @@ test('tag alias', async (ctx) => {
     ])
   })
 
-  await ctx.subtest('auto cleanup interaction with aliases', async () => {
-    // kitty has 0 media_reference_count after alias migration.
-    // With auto_cleanup on, updating media tags triggers delete_unreferenced which
-    // removes the kitty tag record. But the alias rule (slug-based) survives.
+  await ctx.subtest('auto cleanup preserves tags referenced by alias rules', async () => {
+    // kitty has 0 media_reference_count after alias migration, but it's referenced
+    // by an alias rule, so delete_unreferenced should NOT remove it.
     const kitty_before = forager.tag.get({ slug: 'animal:kitty' })
     ctx.assert.equals(kitty_before.tag.media_reference_count, 0)
 
@@ -389,17 +411,22 @@ test('tag alias', async (ctx) => {
     forager.media.update(media_ref_id, {}, { add: ['temp_tag'] })
     forager.media.update(media_ref_id, {}, { remove: ['temp_tag'] })
 
-    // kitty tag record should be gone now (0 refs + auto_cleanup)
+    // kitty tag record should survive (referenced by alias rule)
+    const kitty_after = forager.tag.get({ slug: 'animal:kitty' })
+    ctx.assert.equals(kitty_after.tag.media_reference_count, 0)
+
+    // cat still lists kitty as a resolved alias
+    const cat = forager.tag.get({ slug: 'animal:cat' })
+    ctx.assert.list_partial(cat.aliases, [
+      { slug: 'animal:kitty' },
+      { slug: 'animal:dog' },
+    ])
+
+    // temp_tag (no rules) was cleaned up
     ctx.assert.throws(
-      () => forager.tag.get({ slug: 'animal:kitty' }),
+      () => forager.tag.get({ slug: 'temp_tag' }),
       errors.NotFoundError,
     )
-
-    // but the alias rule still exists — cat no longer lists kitty as resolved alias
-    const cat = forager.tag.get({ slug: 'animal:cat' })
-    // kitty and dog are gone from resolved aliases (both have 0 refs and were cleaned)
-    // only unresolved rules remain in the DB, but they're filtered from the response
-    ctx.assert.list_partial(cat.aliases, [])
   })
 })
 

--- a/packages/core/test/tag.test.ts
+++ b/packages/core/test/tag.test.ts
@@ -158,7 +158,7 @@ test('tag actions', async (ctx) => {
     doodle = forager.media.update(doodle.media_reference.id, {}, {replace: []})
     ctx.assert.list_partial(doodle.tags, [])
     // now observe that the tag _does_ exist when we include zero-reference-count tags
-    ctx.assert.tag_search_result(forager.tag.search({include_zero_reference_count: true}), {
+    ctx.assert.tag_search_result(forager.tag.search({include_unreferenced_tags: true}), {
       total: 6,
       results: [
         {group: '', name: 'wallpaper', media_reference_count: 2},
@@ -196,7 +196,7 @@ test('tag actions', async (ctx) => {
     })
 
     // with include_zero_reference_count, foobar shows up
-    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'media_reference_count', include_zero_reference_count: true}), {
+    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'media_reference_count', include_unreferenced_tags: true}), {
       total: 6,
       results: [
         {group: '', name: 'wallpaper', media_reference_count: 2},
@@ -212,7 +212,7 @@ test('tag actions', async (ctx) => {
     await ctx.timeout(10)
     forager.media.update(doodle.media_reference.id, {}, {add: ['genre:cartoon']})
 
-    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'updated_at', include_zero_reference_count: true}), {
+    ctx.assert.tag_search_result(forager.tag.search({sort_by: 'updated_at', include_unreferenced_tags: true}), {
       results: [
         {name: 'cartoon', media_reference_count: 2},
         {group: '', name: 'foobar', media_reference_count: 0},

--- a/packages/web/src/routes/tags/runes/queryparams.svelte.ts
+++ b/packages/web/src/routes/tags/runes/queryparams.svelte.ts
@@ -41,7 +41,7 @@ export class TagQueryParams extends BaseQueryParams<SearchParams> {
       sort_by: params.sort_by,
       order: params.order,
       limit,
-      include_zero_reference_count: true,
+      include_unreferenced_tags: true,
     }
     if (params.search_string) {
       search_options.query = { tag_match: params.search_string }

--- a/packages/web/src/routes/tags/runes/queryparams.svelte.ts
+++ b/packages/web/src/routes/tags/runes/queryparams.svelte.ts
@@ -41,6 +41,7 @@ export class TagQueryParams extends BaseQueryParams<SearchParams> {
       sort_by: params.sort_by,
       order: params.order,
       limit,
+      include_zero_reference_count: true,
     }
     if (params.search_string) {
       search_options.query = { tag_match: params.search_string }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Tag.delete_unreferenced` deletes all tags with `media_reference_count = 0`, but this doesn't account for tags that are referenced by alias or parent rules in the `tag_alias` and `tag_parent` tables. When a tag becomes an alias (e.g. `animal:kitty` → `animal:cat`), its media references are migrated to the canonical tag, dropping its count to 0. The next auto-cleanup then deletes the alias tag record, breaking `forager.tag.get` which joins alias rules to their `tag` table entries.

## Solution

Two changes:

### 1. `Tag.delete_unreferenced` preserves rule-referenced tags

The DELETE query now excludes tags whose slug appears in any of:
- `tag_alias.alias_tag_slug`
- `tag_alias.alias_for_tag_slug`
- `tag_parent.child_tag_slug`
- `tag_parent.parent_tag_slug`

### 2. `tag.search` hides unreferenced tags by default

Added `include_unreferenced_tags` option (default `false`) to `TagSearch` input. When false, `select_paginated` adds `WHERE tag.media_reference_count > 0`. The web `/tags` page passes `include_unreferenced_tags: true` to show all tags including those with zero references (e.g. alias-only tags).

## Changes

- `packages/core/src/models/tag.ts` — Updated `#delete_by_count` SQL and `select_paginated` signature/logic
- `packages/core/src/inputs/tag_search_input.ts` — Added `include_unreferenced_tags` field
- `packages/core/src/actions/tag_actions.ts` — Pass through `include_unreferenced_tags`
- `packages/web/src/routes/tags/runes/queryparams.svelte.ts` — Set `include_unreferenced_tags: true`
- `packages/core/test/tag.test.ts` — Updated tests to verify new behavior

## Testing

- All 7 tag tests pass (37 steps, 0 failures)
- Lint passes
- Web package builds successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aa9f482-1753-493c-a884-4a069c4d36a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aa9f482-1753-493c-a884-4a069c4d36a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

