### PR TITLE
Add CORS support with origin validation to server hooks

### DIFF
--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -5,6 +5,10 @@ import { dev, building } from '$app/environment'
 import { type Config, load_config, PackagesConfig } from '$lib/server/config.ts'
 import { trace } from "@opentelemetry/api"
 
+const ALLOWED_ORIGINS = new Set([
+  'http://localhost:5173',
+  'http://localhost:8000',
+])
 
 let forager: Forager
 let config: Config
@@ -43,8 +47,33 @@ export const handle: sveltekit.Handle = async ({ event, resolve }) => {
     const url_pathname = new URL(event.request.url).pathname
     span.updateName(`${event.request.method} ${url_pathname}`)
   }
+
+  const origin = event.request.headers.get('origin')
+  if (origin !== null) {
+    if (!ALLOWED_ORIGINS.has(origin)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+
+    // handle CORS preflight
+    if (event.request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': origin,
+          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        }
+      })
+    }
+  }
+
   event.locals.forager = forager
   event.locals.config = config
   const response = await resolve(event)
+
+  if (origin !== null) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+  }
+
   return response
 }


### PR DESCRIPTION
## Summary
This PR adds Cross-Origin Resource Sharing (CORS) support to the SvelteKit server hooks with strict origin validation. The implementation restricts cross-origin requests to a whitelist of allowed origins and properly handles CORS preflight requests.

## Key Changes
- Added `ALLOWED_ORIGINS` set containing whitelisted origins (`http://localhost:5173` and `http://localhost:8000`)
- Implemented origin validation that rejects requests from non-whitelisted origins with a 403 Forbidden response
- Added CORS preflight request handling for OPTIONS method requests
- Set `Access-Control-Allow-Origin` header on all responses from allowed origins
- Configured allowed HTTP methods (GET, POST, PUT, DELETE, OPTIONS) and headers (Content-Type) for CORS requests

## Implementation Details
- Origin validation occurs early in the request handling pipeline, before route resolution
- Preflight requests (OPTIONS method) are handled with a 204 No Content response and appropriate CORS headers
- The `Access-Control-Allow-Origin` header is only added to responses when the request origin is present and allowed
- The whitelist approach ensures only explicitly permitted origins can make cross-origin requests to this server

https://claude.ai/code/session_0169yv9FesefMnQx6m5JBVa1