### PR TITLE
fix(core,web,cli) github action ffmpeg bump 8.0 -> 8.1

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup FFMPEG
         uses: AnimMouse/setup-ffmpeg@v1
         with:
-          version: "8.0"
+          version: "8.1"
 
       # - name: Lint
       # lint source code & jsr publish requirements. Currently disabled because we should get jsr published before addressing

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup FFmpeg
         uses: AnimMouse/setup-ffmpeg@v1
         with:
-          version: "8.0"
+          version: "8.1"
 
       - name: Cache Deno dependencies 
         uses: actions/cache@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup FFmpeg
         uses: AnimMouse/setup-ffmpeg@v1
         with:
-          version: "8.0"
+          version: "8.1"
 
       # - name: Lint
       # run: deno task lint


### PR DESCRIPTION
It seems like ffmpeg builds 8.0 were [removed](https://github.com/BtbN/FFmpeg-Builds/releases/tag/latest) from the builds that our [github ffmpeg setup action](https://github.com/AnimMouse/setup-ffmpeg) uses. Bumping to 8.1 to try and fix