### PR TITLE
docs: add Cursor Cloud specific development instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -890,3 +890,33 @@ Forager is a well-architected media management system with:
 - Migration-based schema evolution
 
 When working on this codebase, prioritize type safety, follow established patterns, write tests, and maintain the clean separation of concerns across layers.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Deno stable** (not canary) must be used for the web package build. The Deno canary channel has a regression where dynamic `import()` of bare specifiers fails inside the `.deno/` node_modules directory during vite build. Use Deno stable 2.7.x.
+- **FFmpeg** is pre-installed at `/usr/bin/ffmpeg` and `/usr/bin/ffprobe`.
+- **No external services** are needed — the database is embedded SQLite and the web server is built into the CLI.
+
+### Running services
+
+- **GUI server**: `deno task --cwd packages/cli develop --config <config_path> gui` starts the web UI on `127.0.0.1:8000`. Requires a YAML config file (see AGENTS.md main section for schema). A minimal config needs `core.database.folder`, `core.database.filename`, `core.thumbnails.folder`, `core.migrations.automatic: true`, and `web.port`.
+- **Dev mode** (with HMR): `deno task develop` first builds the web package then starts the CLI GUI. This is the recommended dev workflow.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Lint (core) | `deno task --cwd packages/core lint` |
+| Test (core) | `deno task --cwd packages/core test` |
+| Test (CLI) | `deno task --cwd packages/cli test` (requires web build first) |
+| Build (web) | `deno task --cwd packages/web build` |
+| Format | `deno fmt` |
+| Full dev | `deno task develop` |
+
+### Known test quirks
+
+- Core tests have 4 failures related to FFmpeg version-specific floating-point precision (duration values differ slightly from expected). These are not code bugs.
+- CLI tests require the web package to be built first (`deno task --cwd packages/web build`).
+- The `--env-file=../../.env` warning from CLI develop tasks is harmless if no `.env` file exists.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -895,7 +895,7 @@ When working on this codebase, prioritize type safety, follow established patter
 
 ### Environment
 
-- **Deno stable** (not canary) must be used for the web package build. The Deno canary channel has a regression where dynamic `import()` of bare specifiers fails inside the `.deno/` node_modules directory during vite build. Use Deno stable 2.7.x.
+- **Deno stable** (not canary) must be used for the web package build. Deno canary has a regression where bare specifiers (e.g. `import 'zimmerframe'` inside `svelte/src/compiler/index.js`) are resolved as relative paths during vite's config evaluation, causing `Unable to load .../svelte/compiler` errors. The root cause: when vite loads vite.config.ts, it evaluates `@sveltejs/kit`'s `import_peer('svelte/compiler')` which loads `node_modules/svelte/src/compiler/index.js`; that file's `import 'zimmerframe'` is then incorrectly resolved as `./zimmerframe` instead of using Node module resolution. `nodeModulesDir: "manual"` + `npm install` does NOT fix this because the issue is in Deno canary's module loader (not the node_modules layout). Use Deno stable 2.7.x.
 - **FFmpeg** is pre-installed at `/usr/bin/ffmpeg` and `/usr/bin/ffprobe`.
 - **No external services** are needed — the database is embedded SQLite and the web server is built into the CLI.
 
@@ -911,7 +911,8 @@ When working on this codebase, prioritize type safety, follow established patter
 | Lint (core) | `deno task --cwd packages/core lint` |
 | Test (core) | `deno task --cwd packages/core test` |
 | Test (CLI) | `deno task --cwd packages/cli test` (requires web build first) |
-| Build (web) | `deno task --cwd packages/web build` |
+| Build (web) | `deno task --cwd packages/web build` or `build:local` |
+| Dev (web HMR) | `deno task --cwd packages/web dev` (vite dev on port 5173) |
 | Format | `deno fmt` |
 | Full dev | `deno task develop` |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment and documents key findings about a Deno canary regression that breaks web package builds.

### Changes
- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
  - Detailed documentation of the Deno canary bare specifier regression
  - Environment requirements (Deno stable, FFmpeg)
  - Key commands table (lint, test, build, dev)
  - Known test quirks

### Investigation: Deno Canary Bare Specifier Regression

**Root cause identified**: When vite evaluates `vite.config.ts`, `@sveltejs/kit`'s `import_peer('svelte/compiler')` loads `node_modules/svelte/src/compiler/index.js`. That file's `import { walk } from 'zimmerframe'` is resolved as a **relative path** (`./zimmerframe`) instead of using Node module resolution on Deno canary (2.7.14+d6212d4, TypeScript 6.0.3).

**What was tested:**
- `nodeModulesDir: "manual"` + `npm install` → Same failure (issue is in Deno's module loader, not node_modules layout)
- `nodeModulesDir: "auto"` + `npm install` overlay → Same failure
- `nodeModulesDir: "none"` → Different failure (lifecycle scripts can't run)
- Vite `--configLoader native` / `--configLoader runner` → Same failure
- Direct `deno eval` / `deno run` of the same import chain → Works fine

**Conclusion**: The issue is a Deno canary regression in how bare specifiers are resolved during vite's module evaluation. Neither changing `nodeModulesDir` nor using npm alongside deno install fixes it. **Deno stable 2.7.14 works correctly.**

### Environment Verification

| Service | Command | Result |
|---------|---------|--------|
| Lint (core) | `deno task --cwd packages/core lint` | ✅ 71 files |
| Test (core) | `deno task --cwd packages/core test` | ✅ 26 passed, 4 known failures |
| Build (web) | `deno task --cwd packages/web build:local` | ✅ Built in ~7s |
| Dev (web) | `deno task --cwd packages/web dev` | ✅ Vite 7.1.8 on :5173 |
| Test (CLI) | `deno task --cwd packages/cli test` | ✅ 2 passed |

Build output log:
[web_build_local_output.log](https://cursor.com/agents/bc-117d5196-e5de-4299-a655-28f6e9433d97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_build_local_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-117d5196-e5de-4299-a655-28f6e9433d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-117d5196-e5de-4299-a655-28f6e9433d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

