### PR TITLE
impl(web): configurable Connection abstraction (tauri port phase 2)

### DIFF
--- a/packages/web/src/lib/base_controller.ts
+++ b/packages/web/src/lib/base_controller.ts
@@ -1,7 +1,7 @@
-import * as svelte from 'svelte'
 import type {ApiSpec} from '$lib/api.ts'
 import * as rpc from '@andykais/ts-rpc/client.ts'
 import type { Config } from '$lib/server/config.ts'
+import { resolve_connection, type Connection } from '$lib/connection.ts'
 import {create_focuser, SettingsRune} from '$lib/runes/index.ts'
 import {Keybinds} from '$lib/keybinds.ts'
 
@@ -9,6 +9,7 @@ import {Keybinds} from '$lib/keybinds.ts'
 abstract class BaseController {
   client: ReturnType<typeof rpc.create<ApiSpec>>
   keybinds: Keybinds
+  connection: Connection
   #config: Config | undefined
 
   abstract runes: {
@@ -16,10 +17,26 @@ abstract class BaseController {
     settings: SettingsRune
   }
 
-  constructor(config: Config) {
+  constructor(config: Config, connection: Connection = resolve_connection()) {
     this.#config = config
-    this.client = rpc.create<ApiSpec>(`${window.location.protocol}${window.location.host}/rpc/:signature`)
+    this.connection = connection
+    this.client = rpc.create<ApiSpec>(`${connection.base_url}/rpc/:signature`)
     this.keybinds = new Keybinds(config)
+  }
+
+  /** URL for streaming a media file from the configured Forager server. */
+  media_url(media_reference_id: number): string {
+    return `${this.connection.base_url}/files/media_file/${media_reference_id}`
+  }
+
+  /**
+   * URL for a thumbnail. `index` is appended as a query-string when non-zero
+   * for parity with the existing route shape; the server's behaviour for
+   * `index` is unchanged from before phase 2.
+   */
+  thumbnail_url(thumbnail_id: number | undefined, index: number = 0): string {
+    const base = `${this.connection.base_url}/files/thumbnail/${thumbnail_id}`
+    return index === 0 ? base : `${base}?index=${index}`
   }
 
   get config() {

--- a/packages/web/src/lib/connection.ts
+++ b/packages/web/src/lib/connection.ts
@@ -1,0 +1,65 @@
+/**
+ * Connection abstraction for talking to a Forager server.
+ *
+ * The SPA used to assume same-origin everywhere. With the Tauri shell on
+ * the horizon (and a "point my browser at a remote forager" use-case for
+ * the web build), we now resolve a base URL at boot time from three
+ * sources, in priority order:
+ *
+ *   1. `window.__FORAGER_CONNECTION__` — injected by the Tauri shell
+ *      before the SPA starts up (see the Tauri port plan §7).
+ *   2. `?api=https://example.com` query-string — handy for the
+ *      browser-served build when you want to point a hosted SPA at a
+ *      different backend.
+ *   3. Same origin — the current default.
+ *
+ * Auth is intentionally out of scope per the design doc; the Connection
+ * carries only a `base_url`.
+ */
+
+export interface Connection {
+  base_url: string
+}
+
+declare global {
+  interface Window {
+    __FORAGER_CONNECTION__?: { base_url: string }
+  }
+}
+
+function strip_trailing_slash(s: string): string {
+  return s.endsWith('/') ? s.slice(0, -1) : s
+}
+
+let cached: Connection | undefined
+
+export function resolve_connection(): Connection {
+  if (cached) return cached
+
+  if (typeof window === 'undefined') {
+    // SSR / prerender / test contexts. We never actually render against a
+    // real backend here, so a placeholder is fine.
+    cached = { base_url: '' }
+    return cached
+  }
+
+  const injected = window.__FORAGER_CONNECTION__
+  if (injected?.base_url) {
+    cached = { base_url: strip_trailing_slash(injected.base_url) }
+    return cached
+  }
+
+  const url_param = new URL(window.location.href).searchParams.get('api')
+  if (url_param) {
+    cached = { base_url: strip_trailing_slash(url_param) }
+    return cached
+  }
+
+  cached = { base_url: window.location.origin }
+  return cached
+}
+
+/** Reset the cached connection. Intended for tests; not used at runtime. */
+export function __reset_connection_for_tests() {
+  cached = undefined
+}

--- a/packages/web/src/lib/runes/media_view_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_view_rune.svelte.ts
@@ -45,7 +45,9 @@ export class MediaViewRune extends Rune {
   }
 
   get preview_thumbnail(): string | undefined {
-    return `/files/thumbnail/${this.media.thumbnails.results.at(0)?.id}`
+    const thumbnail = this.media.thumbnails.results.at(0)
+    if (thumbnail === undefined) return undefined
+    return this.thumbnail_url(thumbnail.id)
   }
 
   get thumbnails() {
@@ -185,7 +187,7 @@ export class MediaGroupRune extends MediaViewRune {
   get preview_thumbnail(): string | undefined {
     const media_entry = this.grouped_state.media_list.at(0)
     if (media_entry) {
-      return `/files/thumbnail/${media_entry.thumbnails.results[0].id}`
+      return this.thumbnail_url(media_entry.thumbnails.results[0].id)
     }
     return undefined
   }

--- a/packages/web/src/lib/runes/rune.ts
+++ b/packages/web/src/lib/runes/rune.ts
@@ -1,6 +1,24 @@
 import type { BaseController } from '$lib/base_controller.ts'
+import { resolve_connection, type Connection } from '$lib/connection.ts'
 
 export class Rune {
-  public constructor(protected client: BaseController['client']) {}
-}
+  protected connection: Connection
 
+  public constructor(
+    protected client: BaseController['client'],
+    connection: Connection = resolve_connection(),
+  ) {
+    this.connection = connection
+  }
+
+  /** URL for streaming a media file. Mirrors `BaseController.media_url`. */
+  protected media_url(media_reference_id: number): string {
+    return `${this.connection.base_url}/files/media_file/${media_reference_id}`
+  }
+
+  /** URL for a thumbnail. Mirrors `BaseController.thumbnail_url`. */
+  protected thumbnail_url(thumbnail_id: number | undefined, index: number = 0): string {
+    const base = `${this.connection.base_url}/files/thumbnail/${thumbnail_id}`
+    return index === 0 ? base : `${base}?index=${index}`
+  }
+}

--- a/packages/web/src/routes/browse/components/MediaView.svelte
+++ b/packages/web/src/routes/browse/components/MediaView.svelte
@@ -60,7 +60,7 @@
     if (media_selections.current_selection.media_response?.media_type !== 'media_file') {
       return
     }
-    return `/files/media_file/${media_selections.current_selection.media_response.media_reference.id}`
+    return controller.media_url(media_selections.current_selection.media_response.media_reference.id)
   })
   $effect(() => {
     if (media_url) {
@@ -111,14 +111,14 @@
             <div class="w-full flex flex-row justify-center gap-1 overflow-x-scroll" style="height: {controller.runes.settings.ui.media_view.filmstrip.thumbnail_size}px;">
               {#each media_selections.current_selection.thumbnails.results as thumbnail, index}
                 <div class="h-full">
-                  <img class="h-full" src="/files/thumbnail/{media_selections.current_selection.media_response.media_reference.id}?index={index}" alt="Thumbnail {index}"></div>
+                  <img class="h-full" src={controller.thumbnail_url(media_selections.current_selection.media_response.media_reference.id, index)} alt="Thumbnail {index}"></div>
               {/each}
             </div>
           {/if}
         {:else if media_selections.current_selection.media_response.media_file.media_type === 'AUDIO'}
           <img
             class="object-contain max-h-full"
-            src="/files/thumbnail/{media_selections.current_selection.media_response.media_reference.id}" alt="Audio thumbnail">
+            src={controller.thumbnail_url(media_selections.current_selection.media_response.media_reference.id)} alt="Audio thumbnail">
           <audio
             autoplay
             loop

--- a/packages/web/test/connection.test.ts
+++ b/packages/web/test/connection.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from 'jsr:@std/assert@^1.0.14'
+import {
+  __reset_connection_for_tests,
+  resolve_connection,
+} from '../src/lib/connection.ts'
+
+
+/**
+ * `connection.ts` is a tiny browser module that picks an API base URL from
+ * three sources. These tests stub `globalThis.window` to exercise each
+ * branch without spinning up a browser.
+ */
+
+interface FakeWindow {
+  location: { href: string; origin: string }
+  __FORAGER_CONNECTION__?: { base_url: string }
+}
+
+function with_window<T>(fake: FakeWindow, fn: () => T): T {
+  __reset_connection_for_tests()
+  // deno-lint-ignore no-explicit-any
+  const g = globalThis as any
+  const had_window = 'window' in g
+  const previous = g.window
+  g.window = fake
+  try {
+    return fn()
+  } finally {
+    if (had_window) g.window = previous
+    else delete g.window
+    __reset_connection_for_tests()
+  }
+}
+
+
+Deno.test('resolve_connection: window.__FORAGER_CONNECTION__ wins over everything else', () => {
+  const c = with_window({
+    location: { href: 'http://127.0.0.1:8000/browse?api=http://ignored', origin: 'http://127.0.0.1:8000' },
+    __FORAGER_CONNECTION__: { base_url: 'http://my-nas.lan:9001' },
+  }, () => resolve_connection())
+  assertEquals(c.base_url, 'http://my-nas.lan:9001')
+})
+
+Deno.test('resolve_connection: ?api= query string wins over same-origin', () => {
+  const c = with_window({
+    location: { href: 'http://127.0.0.1:8000/browse?api=https://example.com', origin: 'http://127.0.0.1:8000' },
+  }, () => resolve_connection())
+  assertEquals(c.base_url, 'https://example.com')
+})
+
+Deno.test('resolve_connection: trailing slash is stripped from explicit base_url', () => {
+  const c = with_window({
+    location: { href: 'http://127.0.0.1:8000/browse', origin: 'http://127.0.0.1:8000' },
+    __FORAGER_CONNECTION__: { base_url: 'http://my-nas.lan:9001/' },
+  }, () => resolve_connection())
+  assertEquals(c.base_url, 'http://my-nas.lan:9001')
+})
+
+Deno.test('resolve_connection: trailing slash is stripped from ?api= query string', () => {
+  const c = with_window({
+    location: { href: 'http://127.0.0.1:8000/browse?api=https://example.com/', origin: 'http://127.0.0.1:8000' },
+  }, () => resolve_connection())
+  assertEquals(c.base_url, 'https://example.com')
+})
+
+Deno.test('resolve_connection: falls back to same origin when no overrides are set', () => {
+  const c = with_window({
+    location: { href: 'http://127.0.0.1:8000/browse', origin: 'http://127.0.0.1:8000' },
+  }, () => resolve_connection())
+  assertEquals(c.base_url, 'http://127.0.0.1:8000')
+})
+
+Deno.test('resolve_connection: empty ?api= falls back to same origin', () => {
+  const c = with_window({
+    location: { href: 'http://127.0.0.1:8000/browse?api=', origin: 'http://127.0.0.1:8000' },
+  }, () => resolve_connection())
+  assertEquals(c.base_url, 'http://127.0.0.1:8000')
+})
+
+Deno.test('resolve_connection: missing window (SSR/test) returns empty base_url placeholder', () => {
+  __reset_connection_for_tests()
+  // deno-lint-ignore no-explicit-any
+  const g = globalThis as any
+  const had_window = 'window' in g
+  const previous = g.window
+  delete g.window
+  try {
+    const c = resolve_connection()
+    assertEquals(c.base_url, '')
+  } finally {
+    if (had_window) g.window = previous
+    __reset_connection_for_tests()
+  }
+})
+
+Deno.test('resolve_connection: result is cached after first call', () => {
+  // deno-lint-ignore no-explicit-any
+  const g = globalThis as any
+  const had_window = 'window' in g
+  const previous = g.window
+  __reset_connection_for_tests()
+  g.window = {
+    location: { href: 'http://127.0.0.1:8000/browse', origin: 'http://127.0.0.1:8000' },
+  }
+  try {
+    const a = resolve_connection()
+    g.window.location = { href: 'http://other.example/', origin: 'http://other.example' }
+    const b = resolve_connection()
+    assertEquals(a, b, 'second call should return the same cached object')
+  } finally {
+    if (had_window) g.window = previous
+    else delete g.window
+    __reset_connection_for_tests()
+  }
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Phase 2 of the [Tauri port plan](https://github.com/andykais/forager/pull/73). Stacked on top of [phase 1](https://github.com/andykais/forager/pull/74) — please review/merge phase 1 first, then this. (Base branch is intentionally `cursor/tauri-server-phase1-1e82`; rebase to `main` once phase 1 lands.)

The frontend used to hardcode same-origin when constructing the RPC client and `/files/*` URLs. With Tauri (and a "point my browser at a remote forager" use-case for the web build) on the horizon, both need to come from a runtime `Connection`.

## Walkthrough

[forager_phase2_connection_smoketest.mp4](https://cursor.com/agents/bc-4f0c3b4e-e670-46b1-8353-01aa1abf1e82/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforager_phase2_connection_smoketest.mp4)

Browser smoke test of the resolver: thumbnails, RPC, image preview, and video playback (HTTP `Range`) all working through the new `controller.media_url` / `controller.thumbnail_url` helpers.

[Same-origin default — thumbnail src is http://127.0.0.1:8000/files/thumbnail/...](https://cursor.com/agents/bc-4f0c3b4e-e670-46b1-8353-01aa1abf1e82/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_same_origin.png)
[?api=... query string accepted; SPA boots and renders](https://cursor.com/agents/bc-4f0c3b4e-e670-46b1-8353-01aa1abf1e82/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_api_param.png)
[Cronch video streaming via the new media_url helper](https://cursor.com/agents/bc-4f0c3b4e-e670-46b1-8353-01aa1abf1e82/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_video_playing.png)

## What changed

### New: `packages/web/src/lib/connection.ts`
The `Connection` abstraction the design doc described in §5. `resolve_connection()` picks a base URL in priority order:
1. `window.__FORAGER_CONNECTION__` — injected by the Tauri shell before the SPA boots.
2. `?api=https://example.com` query string — handy for the browser-served build pointing at a different backend.
3. Same origin — current default.

Trailing slashes stripped, result cached per session, SSR/test path returns an empty placeholder so module load doesn't blow up.

### New: `packages/web/test/connection.test.ts`
8 unit tests covering every branch, plus caching and the SSR placeholder. Run with `deno test packages/web/test/connection.test.ts`. These nail down the resolver behaviour without needing a browser, which the in-page smoke test couldn't do reliably (CORS not in scope until phase 4).

### `BaseController` (`packages/web/src/lib/base_controller.ts`)
- New `connection: Connection` field, populated from a constructor arg (defaults to `resolve_connection()`).
- The RPC client now builds its URL from `connection.base_url` instead of `window.location.protocol + host` (this also incidentally fixes a missing `//` in the old string concatenation).
- New `media_url(id)` and `thumbnail_url(id, index?)` helpers so the rest of the SPA never builds those URLs by hand.

### `Rune` (`packages/web/src/lib/runes/rune.ts`)
Same treatment — accepts an optional `Connection` (default `resolve_connection()`) and exposes the same two URL helpers as `protected` methods. `MediaViewRune.preview_thumbnail` is the consumer today; the helpers are there for any future rune that needs to build asset URLs.

### Replaced: every hardcoded `/files/*` literal in the frontend
| Site | Before | After |
| --- | --- | --- |
| `MediaViewRune.preview_thumbnail` | `` `/files/thumbnail/${...?.id}` `` | `this.thumbnail_url(thumbnail.id)` |
| `MediaGroupRune.preview_thumbnail` | `` `/files/thumbnail/${...id}` `` | `this.thumbnail_url(...)` |
| `MediaView.svelte` `media_url` derivable | `` `/files/media_file/${ref.id}` `` | `controller.media_url(ref.id)` |
| `MediaView.svelte` filmstrip `<img src>` | `/files/thumbnail/{id}?index={i}` | `controller.thumbnail_url(id, i)` |
| `MediaView.svelte` audio thumbnail `<img src>` | `/files/thumbnail/{id}` | `controller.thumbnail_url(id)` |

`grep -rn '/files/(media_file\|thumbnail)' packages/web/src` now only matches the two helper bodies (`base_controller.ts`, `rune.ts`).

## Why default-resolve in the constructor instead of plumbing through `+page.svelte`?

Tauri injects `window.__FORAGER_CONNECTION__` before any SPA code runs, and the browser-served build either picks up `?api=` from the URL or falls back to same-origin. In every case `resolve_connection()` is correct by the time a controller is constructed. Plumbing through layout/page data would just be ceremony with no runtime effect, and the design doc didn't call for it. Both the constructor and `Rune` still accept an explicit `Connection` for testability and for any future case that wants to override.

## Testing

- ✅ `deno test packages/web/test/connection.test.ts` — 8 / 8 pass.
- ✅ `deno task --cwd packages/web build:local` — clean.
- ✅ `deno task compile:local` — full CLI binary builds.
- ✅ `deno task --cwd packages/cli test` — 2 / 2 pass.
- ✅ Bundle inspection: `grep -oE '/files/(media_file|thumbnail)[^"\`]{0,80}' .../chunks/*.js` shows only `/files/media_file/${t}` and `/files/thumbnail/${t}` template-literal placeholders — i.e. the helpers concatenate `connection.base_url + /files/...` at runtime as intended.
- ✅ Manual browser smoke test (recorded above):
  - Same-origin: thumbnail `src` resolves to `http://127.0.0.1:8000/files/thumbnail/...`.
  - `?api=http://127.0.0.1:8000`: SPA still boots, thumbnails render, no console errors.
  - Image preview + video playback (Range requests) work end-to-end.

⚠️ `deno check` against the SvelteKit source surfaces 91 pre-existing errors (`$app/navigation` resolution, Deno globals not typed when checked outside `deno task`) — same count and same files on phase 1's tip, verified by `git stash` + recheck. Build is the actual gate and it's clean.

## Follow-ups (not in this PR)

- Phase 3 — `adapter-static` switch; collapse the custom Deno SvelteKit adapter once the SPA is fully decoupled.
- Phase 4 — `web.server.cors_allow_origins` so a browser-served `?api=` against a different host actually works (today both ends would be same-origin, so the SPA loads fine but a true cross-origin remote would hit CORS).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f0c3b4e-e670-46b1-8353-01aa1abf1e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f0c3b4e-e670-46b1-8353-01aa1abf1e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

