### PR TITLE
perf(core): hoist ingest_priority lookup out of FilesystemPath insert

### DIFF
--- a/packages/core/src/actions/filesystem_actions.ts
+++ b/packages/core/src/actions/filesystem_actions.ts
@@ -4,6 +4,7 @@ import { Actions } from '~/actions/lib/base.ts'
 import * as torm from '@torm/sqlite'
 import { inputs, parsers } from '~/inputs/mod.ts'
 import * as plugin from '~/lib/plugin_script.ts'
+import { FilesystemPath } from '~/models/filesystem_path.ts'
 
 interface FileSystemDiscoverStats {
   created: {
@@ -60,11 +61,24 @@ class FileSystemActions extends Actions {
     }
 
     this.ctx.logger.info(`Collecting files in ${walk_path}...`)
+
+    // Resolve the starting ingest_priority once for the whole discovery pass.
+    // Previously the model's INSERT did this lookup via a
+    // `(SELECT MAX(ingest_priority) ...)` subquery on every row, which made
+    // `filesystem.discover` quadratic in the size of the table. Within a
+    // single discover() run we are the only writer, so we can safely hand out
+    // priorities by simple in-memory increment.
+    const initial_max_priority = this.models.FilesystemPath.select_max_priority() ?? 0
+    let next_file_priority = initial_max_priority + FilesystemPath.PRIORITY_SPACER
+
     let progress = 0
     for await (const entry of fs.walk(walk_path, walk_options)) {
       const receiver = this.ctx.plugin_script.recievers.find(receiver => receiver.matches(entry))
       if (receiver) {
-        this.#add_filepath(stats, receiver, entry, parsed.params.reingest)
+        const created = this.#add_filepath(stats, receiver, entry, parsed.params.reingest, next_file_priority)
+        if (created) {
+          next_file_priority += FilesystemPath.PRIORITY_SPACER
+        }
       } else {
         stats.ignored.files ++
       }
@@ -79,11 +93,17 @@ class FileSystemActions extends Actions {
     return { stats }
   }
 
-  #add_filepath(stats: FileSystemDiscoverStats, receiver: plugin.FileSystemReceiver, entry: fs.WalkEntry, reingest: boolean) {
+  #add_filepath(
+    stats: FileSystemDiscoverStats,
+    receiver: plugin.FileSystemReceiver,
+    entry: fs.WalkEntry,
+    reingest: boolean,
+    ingest_priority: number,
+  ): boolean {
       const filesystem_path_data = {
         directory: false,
         filepath: entry.path,
-        priority_instruction: 'first',
+        ingest_priority,
         ingested: false,
         ingest_retriever: receiver.name,
         ingested_at: null,
@@ -100,13 +120,14 @@ class FileSystemActions extends Actions {
             updated_at: new Date(),
           })
           stats.existing.files ++
-          return
+          return false
       }
 
       try {
         this.models.FilesystemPath.create(filesystem_path_data)
         stats.created.files ++
         this.#add_directories(stats, path.dirname(entry.path))
+        return true
       } catch (e) {
         if (e instanceof torm.errors.UniqueConstraintError) {
           // this is just being defensive against potential concurrency conflicts that shouldn't arise
@@ -118,8 +139,9 @@ class FileSystemActions extends Actions {
             ingest_retriever: filesystem_path_data.ingest_retriever,
             updated_at: new Date(),
           })
+          return false
         }
-        else throw e
+        throw e
       }
   }
 
@@ -128,7 +150,7 @@ class FileSystemActions extends Actions {
       this.models.FilesystemPath.create({
         directory: true,
         filepath: filepath,
-        priority_instruction: 'none',
+        ingest_priority: null,
         ingested: false,
         ingest_retriever: null,
         ingested_at: null,

--- a/packages/core/src/models/filesystem_path.ts
+++ b/packages/core/src/models/filesystem_path.ts
@@ -3,8 +3,8 @@ import { Model, field } from '~/models/lib/base.ts'
 import { SQLBuilder } from '~/models/lib/sql_builder.ts'
 
 const FilesystemPathVars = torm.Vars({
-  priority_instruction: field.string(), // TODO support enums in torm. This should be constrained to "first" | "last" | "none"
   total: field.number(),
+  priority: field.number().optional(),
 })
 
 
@@ -34,6 +34,15 @@ class FilesystemPath extends Model {
   static params = this.schema.params
   static result = this.schema.result
 
+  static PRIORITY_SPACER = PRIORITY_SPACER
+
+  // NOTE: callers are responsible for supplying an `ingest_priority` value.
+  // Previously this INSERT computed `MAX(ingest_priority) + 1000` inline via a
+  // CASE/subquery, but SQLite chose the `filesystem_path_directory` index over
+  // the partial unique index `filesystem_path_priority`, forcing a full scan
+  // of every `directory=0` row on every insert. During bulk `filesystem.discover`
+  // that made discovery O(n^2). Resolving the next priority once per batch in
+  // application code and passing it as a parameter keeps inserts O(1).
   #create = this.query.one`INSERT INTO filesystem_path (
     filepath,
     filename,
@@ -51,17 +60,22 @@ class FilesystemPath extends Model {
     FilesystemPath.params.ingested,
     FilesystemPath.params.ingest_retriever,
     FilesystemPath.params.ingested_at,
-  ]},
-    CASE
-      WHEN ${FilesystemPathVars.params.priority_instruction} = 'first'
-        THEN COALESCE((SELECT MAX(ingest_priority) FROM filesystem_path WHERE directory = 0), 0) + ${PRIORITY_SPACER}
-      WHEN ${FilesystemPathVars.params.priority_instruction} = 'last'
-        THEN COALESCE((SELECT MIN(ingest_priority) FROM filesystem_path WHERE directory = 0), 0) - ${PRIORITY_SPACER}
-      WHEN ${FilesystemPathVars.params.priority_instruction} = 'none'
-        THEN NULL
-      ELSE 1/0 -- NOTE this is hacky, but it lets us throw an error if we receive a priority_instruction thats an unexpected value
-    END
-  ) RETURNING ${FilesystemPath.result.id}`
+    FilesystemPath.params.ingest_priority,
+  ]}) RETURNING ${FilesystemPath.result.id}`
+
+  // The `INDEXED BY filesystem_path_priority` hint is load-bearing: without it
+  // SQLite picks the non-partial `filesystem_path_directory` index and scans
+  // every directory=0 row. The partial unique index is keyed on
+  // `ingest_priority` and only contains directory=0 rows, so MAX()/MIN()
+  // resolve in O(log n) via a covering index lookup. The `WHERE directory = 0`
+  // clause is required for SQLite to match the partial index.
+  #select_max_priority_q = this.query.one`
+    SELECT MAX(ingest_priority) AS ${FilesystemPathVars.result.priority}
+    FROM filesystem_path INDEXED BY filesystem_path_priority WHERE directory = 0`
+
+  #select_min_priority_q = this.query.one`
+    SELECT MIN(ingest_priority) AS ${FilesystemPathVars.result.priority}
+    FROM filesystem_path INDEXED BY filesystem_path_priority WHERE directory = 0`
 
   #select_by_filepath = this.query`SELECT ${FilesystemPath.result['*']} FROM filesystem_path WHERE filepath = ${FilesystemPath.params.filepath}`
 
@@ -148,6 +162,25 @@ class FilesystemPath extends Model {
   public update = this.#update.exec
 
   public update_ingest = this.#update_filepath_ingest
+
+  /**
+   * Returns the current MAX(ingest_priority) among non-directory rows, or null
+   * if no such rows exist. Uses the partial unique index
+   * `filesystem_path_priority` for an O(log n) lookup.
+   */
+  public select_max_priority(): number | null {
+    const row = this.#select_max_priority_q()
+    return row?.priority ?? null
+  }
+
+  /**
+   * Returns the current MIN(ingest_priority) among non-directory rows, or null
+   * if no such rows exist. See {@link select_max_priority} for index strategy.
+   */
+  public select_min_priority(): number | null {
+    const row = this.#select_min_priority_q()
+    return row?.priority ?? null
+  }
 
   public count_entries(params: SelectFilesystemPathFilters) {
     const builder = new SQLBuilder(this.driver)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

`forager.filesystem.discover()` degraded quadratically as the `filesystem_path` table grew. Each `FilesystemPath.create()` ran a CASE/subquery to compute the next `ingest_priority`:

```sql
CASE
  WHEN :priority_instruction = 'first'
    THEN COALESCE((SELECT MAX(ingest_priority) FROM filesystem_path WHERE directory = 0), 0) + 1000
  WHEN :priority_instruction = 'last'
    THEN COALESCE((SELECT MIN(ingest_priority) FROM filesystem_path WHERE directory = 0), 0) - 1000
  WHEN :priority_instruction = 'none'
    THEN NULL
  ELSE 1/0
END
```

The schema does have a partial unique index that should make this O(log n):

```sql
CREATE UNIQUE INDEX filesystem_path_priority
  ON filesystem_path (ingest_priority) WHERE directory = 0;
```

But SQLite's planner picks `filesystem_path_directory` (the plain index on `directory`) and does a full scan of every `directory=0` row to find the MAX. `EXPLAIN QUERY PLAN` confirmed it:

```
SEARCH filesystem_path USING INDEX filesystem_path_directory (directory=?)
```

So every insert paid an O(n) probe, making bulk discovery O(n²).

## Fix

Two layered changes:

1. **Model (`packages/core/src/models/filesystem_path.ts`)**
   - Remove the CASE/subquery from the INSERT — `#create` now binds `ingest_priority` directly as a parameter.
   - Add `select_max_priority()` / `select_min_priority()` helpers that pin the partial unique index via `INDEXED BY filesystem_path_priority`. With the hint, SQLite uses a covering-index lookup (`SEARCH ... USING COVERING INDEX filesystem_path_priority`), turning the probe into O(log n).
   - Expose `PRIORITY_SPACER` as a static so callers can replicate the existing "+ 1000 per row" stride.

2. **Actions (`packages/core/src/actions/filesystem_actions.ts`)**
   - Resolve `MAX(ingest_priority)` exactly once at the start of `discover()`, then hand out monotonically increasing priorities by simple in-memory increment per newly-created row. Within a single `discover()` pass we are the only writer, so the partial unique constraint is still preserved.
   - `#add_filepath` now returns whether it inserted (so the loop only advances the counter on actual creations).

## Benchmark

Single discover loop, fresh DB, WAL on, Linux.

| rows inserted | before (per-insert) | after (per-insert) |
| ------------- | ------------------- | ------------------ |
| 0 → 1k        | 0.84 ms             | 1.24 ms            |
| 1k → 5k       | 1.62 ms             | 1.20 ms            |
| 5k → 10k      | 1.18 ms             | 1.10 ms            |
| 10k → 20k     | 2.93 ms             | 0.59 ms            |
| 20k → 40k     | **10.26 ms**        | **1.19 ms**        |
| 40k → 80k     | n/a                 | 1.67 ms            |

Before: linear per-insert growth → O(n²) total. After: flat per-insert cost → O(n) total. At 40k rows the per-row cost dropped ~8.5x; the gap widens further with table size (the original 40k → 80k batch would have taken ~30+ minutes; the new path finishes in ~67s).

Standalone `select_max_priority()` benchmark on a populated table runs in ~0.004 ms thanks to:

```
SEARCH filesystem_path USING COVERING INDEX filesystem_path_priority
```

## Testing

- ✅ `deno check packages/core/src/mod.ts`
- ✅ `deno task --cwd packages/core lint`
- ✅ `deno test ... --filter 'ingest actions'` (exercises the new discover flow end-to-end)
- ✅ Full `deno test` core suite: 26 tests pass; the 4 pre-existing failures are all duration/ffprobe floating-point precision issues called out in `AGENTS.md` ("Audio duration: 6.96 vs 6.92", keypoint timestamp precision) and reproduce on `main` unchanged.

## Compatibility notes

- `FilesystemPath.create({ priority_instruction: ... })` is gone. Callers pass `ingest_priority: number | null` directly. The two in-tree callers (`#add_filepath` for files, `#add_directories` for directories) are updated.
- No migration is needed — schema and indexes are unchanged. Only the SQL the model emits changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7628bd12-6daa-413d-83aa-f44a20a708a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7628bd12-6daa-413d-83aa-f44a20a708a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

