### PR TITLE
fix(web): get `deno task check` passing and add it to CI

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,12 +40,12 @@ jobs:
       # - name: Lint
       # run: deno task lint
 
-      # - name: Typecheck
-      # run: deno task check
-
       # package.json based projects need to run deno install step
       - name: Install Dependencies
         run: deno install --allow-scripts
+
+      - name: Typecheck
+        run: deno task check
 
       - name: Build
         run: deno task build

--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,7 @@
     "@std/datetime": "jsr:@std/datetime@^0.225.3",
     "@std/yaml": "jsr:@std/yaml@^1.0.5",
     "@std/fmt": "jsr:@std/fmt@0.225.6",
+    "@std/fmt/bytes": "jsr:@std/fmt@0.225.6/bytes",
     "@std/fs": "jsr:@std/fs@0.229.3",
     "@std/log": "jsr:@std/log@^0.224.6",
     "@std/media-types": "jsr:@std/media-types@0.224.0",
@@ -31,5 +32,6 @@
   "unstable": ["raw-imports"],
 
   "nodeModulesDir": "auto",
+  "jsrDepsInNodeModules": true,
   "allowScripts": ["npm:@sveltejs/kit@2.5.24", "npm:@tailwindcss/oxide@4.1.14", "npm:esbuild@0.25.10", "npm:fsevents@2.3.3"]
 }

--- a/deno.lock
+++ b/deno.lock
@@ -67,6 +67,13 @@
     "jsr:@torm/sqlite@^1.9.7": "1.9.7",
     "npm:@deno/vite-plugin@1.0.6": "1.0.6_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:@jsr/andykais__ts-rpc@~0.2.4": "0.2.4_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@jsr/std__datetime@~0.225.3": "0.225.7",
+    "npm:@jsr/std__fmt@0.225.6": "0.225.6",
+    "npm:@jsr/std__fs@0.229.3": "0.229.3",
+    "npm:@jsr/std__log@~0.224.6": "0.224.14",
+    "npm:@jsr/std__media-types@0.224.0": "0.224.0",
+    "npm:@jsr/std__path@1.0.3": "1.0.3",
+    "npm:@jsr/std__yaml@^1.0.5": "1.1.2",
     "npm:@jsr/torm__sqlite@^1.9.7": "1.9.7",
     "npm:@opentelemetry/api@1.9.0": "1.9.0",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
@@ -74,11 +81,13 @@
     "npm:@sveltejs/kit@2.5.24": "2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:@sveltejs/vite-plugin-svelte@6.2.1": "6.2.1_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:@tailwindcss/vite@4.1.14": "4.1.14_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@types/deno@^2.5.0": "2.7.0",
     "npm:@types/node@*": "24.2.0",
     "npm:esbuild@*": "0.25.10",
     "npm:path-to-regexp@6.2.1": "6.2.1",
     "npm:sv@*": "0.12.5",
     "npm:sv@latest": "0.12.5",
+    "npm:svelte-check@*": "4.3.2_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3",
     "npm:svelte-check@4.3.2": "4.3.2_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3",
     "npm:svelte@5.39.8": "5.39.8_acorn@8.15.0",
     "npm:svelte@~5.39.8": "5.39.8_acorn@8.15.0",
@@ -574,7 +583,7 @@
     "@jsr/std__assert@0.226.0": {
       "integrity": "sha512-xCuUFDfHkIZd96glKgjZbnYFqu6blu8Y53SyvDMlFDJm1Y/j+/FcW6xq7TzGFIaF5B9QecIlDfamfhzA8ZdVbg==",
       "dependencies": [
-        "@jsr/std__internal@1.0.10"
+        "@jsr/std__internal@1.0.14"
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__assert/0.226.0.tgz"
     },
@@ -628,6 +637,10 @@
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__crypto/0.224.0.tgz"
     },
+    "@jsr/std__datetime@0.225.7": {
+      "integrity": "sha512-z1N0Ompk9zzcrwExq2uMxGAvnXDjV9W9m5Lun+OE27/Y2F+jvDWdZ766a28h+U3XKKoDq0hByYVuhOZ7pzWuhw==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__datetime/0.225.7.tgz"
+    },
     "@jsr/std__encoding@0.223.0": {
       "integrity": "sha512-auQ0wUZFsVGXU+6qfjGeonWe8utBhp+y43etR1lanCJXXUzL5W3yS+i73Fki+RLjvxUG4Pwd1CrGSR57kIvrIg==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__encoding/0.223.0.tgz"
@@ -651,6 +664,25 @@
     "@jsr/std__fmt@0.225.6": {
       "integrity": "sha512-5wll7CImyrJfen4fecziNSxZ5S6Fo3H1rQqKMQDewRGHAnFVqcHLe8wwCuDLK+HTbSPy6AkR3b136WpjVdOjTQ==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__fmt/0.225.6.tgz"
+    },
+    "@jsr/std__fmt@1.0.10": {
+      "integrity": "sha512-Q2N8XDNkh/c1IKTi+sO4Vm64M5m4W0o47qTURmMX0vgHm9AJ6jL7jEQ2kw0M1T2rBZiwAY78eUbYzFyOYWaCqQ==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.10.tgz"
+    },
+    "@jsr/std__fs@0.229.3": {
+      "integrity": "sha512-hXsLcP1dumz3VbRKVhPtzs7Wigxhqp2rtBzwzrF9Cz9IMqZkp7EoKHxeqcUiduf7yYxVV/vbnfhjqbOLvlljjA==",
+      "dependencies": [
+        "@jsr/std__path@1.0.0-rc.1"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__fs/0.229.3.tgz"
+    },
+    "@jsr/std__fs@1.0.24": {
+      "integrity": "sha512-UunW2Rg++9sA74NJnYMGTsMVQgoFRAwPP02wRRohL0PQBNorbyxHiyCMRaxYQCtLepTLkC4nUyMtcwrGKqTR6g==",
+      "dependencies": [
+        "@jsr/std__internal@1.0.14",
+        "@jsr/std__path@1.1.6"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.24.tgz"
     },
     "@jsr/std__http@0.223.0": {
       "integrity": "sha512-v60Hv8J1GXM1ExsJgBXVcmhbyt4Ip3RFaIdkVrycujbBL5qFuhNnvkmggAonP+nwXy5V0crU/tkLNWTyncoPXQ==",
@@ -687,9 +719,9 @@
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__internal/0.224.0.tgz"
     },
-    "@jsr/std__internal@1.0.10": {
-      "integrity": "sha512-fmD6yKep/sMnB2yPQU/REZG7Z4N9SZwcUBNnceo4QkXk67l3JEfxHoROQ/YHeVSOmq6x55Ra6nuMjz2ib3nj3g==",
-      "tarball": "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.10.tgz"
+    "@jsr/std__internal@1.0.14": {
+      "integrity": "sha512-JT8b/t40WcR9q0GDwRZUooY7aXeXnFal8iidE/5TckdAFtvpVAsaJ71/Xgf1SfoChs41s6CZkuCYM8toaNgdvA==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.14.tgz"
     },
     "@jsr/std__io@0.223.0": {
       "integrity": "sha512-VUPpfHeLvhooQFyujLSj6/KDCqgF+joBpb6eO9dg+JJWvy5wHj1Nl2EMRQe6Pl8nNVUwjt+ZraydkGTdlDS1jw==",
@@ -706,9 +738,29 @@
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__io/0.224.9.tgz"
     },
+    "@jsr/std__io@0.225.3": {
+      "integrity": "sha512-IDXY253ipW6FV34CJVxO+3ubfvSEEzw9N2W303KnLe9K/Y9+v/ID1dQYf9VsCCOFMpFtCmOLqzIZsRqv6yQnWw==",
+      "dependencies": [
+        "@jsr/std__bytes@1.0.6"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__io/0.225.3.tgz"
+    },
+    "@jsr/std__log@0.224.14": {
+      "integrity": "sha512-EHT7E0plakyzk/gxMrwqUf3YGCCxN3Is25QrEh7toYA7qwj46R4qY7cIaDEKy8QqI5JHOFHwWXOClcPK6goIoQ==",
+      "dependencies": [
+        "@jsr/std__fmt@1.0.10",
+        "@jsr/std__fs@1.0.24",
+        "@jsr/std__io@0.225.3"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__log/0.224.14.tgz"
+    },
     "@jsr/std__media-types@0.223.0": {
       "integrity": "sha512-wJe0dRZiL1OqU8oGXReVuMK5stHERyGgpR/6yS4qW9+p74+XXSIP+OGubfzl8TjeKeULd82zLbk1QNo5FvwXNw==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__media-types/0.223.0.tgz"
+    },
+    "@jsr/std__media-types@0.224.0": {
+      "integrity": "sha512-ua4EvwuGmFFB0KREfJGROd+EeVxGE6IwNJnfP4jHGyIuH7JLxX78r1cNbPxVjTrNso2GbjFdBQ2pKcyPQOOhUQ==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__media-types/0.224.0.tgz"
     },
     "@jsr/std__media-types@0.224.1": {
       "integrity": "sha512-L3kF5zNOA0KNibbdKwxmjaHUOpa7vWTb6BNwv41QZEjOtmS8GWPTRAXkglLEUfu2gl6pXlOoT3BmXv/naO5tKA==",
@@ -729,9 +781,24 @@
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/0.223.0.tgz"
     },
+    "@jsr/std__path@1.0.0-rc.1": {
+      "integrity": "sha512-bGolWCcaF8HGT0QVZr/heEaHm6MEgpOI7LyrV4JLuBYrLb81FAX7m3Li77JnF06RNhJViY8K7zvPpuVIiakyvA==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/1.0.0-rc.1.tgz"
+    },
     "@jsr/std__path@1.0.0-rc.2": {
       "integrity": "sha512-qUHfVMqAtMGPFmdkOfmkCONqgpe4UFVAaD+wL6ZdlQxtvQiNxHQWsje+djri+0095s/kkoBOPH4CpYxBq+zh3A==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/1.0.0-rc.2.tgz"
+    },
+    "@jsr/std__path@1.0.3": {
+      "integrity": "sha512-XH7cE38WHq4J3ICVKrVs0GvKf9EXfMxAzvXkVewHXJeyh7TW/bN47yIPArDQUybHlyLkTQvQaDW0hWDY3TP2xQ==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/1.0.3.tgz"
+    },
+    "@jsr/std__path@1.1.6": {
+      "integrity": "sha512-H1Cmg6z8jFyIsQbVV+vZB4eOx4k6Qg8lyUM6l7nZysj5MZumg89kb0M1bsPBTGQis3fw6mJFkJELo5+AK6oCFA==",
+      "dependencies": [
+        "@jsr/std__internal@1.0.14"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/1.1.6.tgz"
     },
     "@jsr/std__streams@0.223.0": {
       "integrity": "sha512-YfOfRTpnTocgC5h22aRMgu74ByBO6763PgwG2p7iFWYZFBRrDNW6WqYK1MFXcbU8VrwlgpUEvkS3Xk9dJnd+hw==",
@@ -749,6 +816,10 @@
         "@jsr/std__io@0.224.9"
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__streams/0.224.5.tgz"
+    },
+    "@jsr/std__yaml@1.1.2": {
+      "integrity": "sha512-R2U09+AG6VgFet8qmVhkFw1eKQKeG54RAejd64G5F0XrzMFmHp6KOMnabOdSowd7kj28wFt/x4XT2ARGZEEeVw==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__yaml/1.1.2.tgz"
     },
     "@jsr/torm__sqlite@1.9.7": {
       "integrity": "sha512-naligACB12UtWD43fd0QtUCIgNotPoiib3r/qFHAMj0Hy2RxapfR24dSH2U5gHQM4DSBCt2/sqwcjojY2T3SMw==",
@@ -1059,6 +1130,9 @@
     },
     "@types/cookie@0.6.0": {
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
+    "@types/deno@2.7.0": {
+      "integrity": "sha512-Y6fWcV8KpYeO3Lik/RiYnUxtr/LWqoeACciU0CA+dr1U/45tGgaX3HWQQAPCNN53raN4Rr4Fht4y6qsUH57fDA=="
     },
     "@types/estree@1.0.8": {
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
@@ -1549,17 +1623,27 @@
           "dependencies": [
             "npm:@deno/vite-plugin@1.0.6",
             "npm:@jsr/andykais__ts-rpc@~0.2.4",
+            "npm:@jsr/std__datetime@~0.225.3",
+            "npm:@jsr/std__fmt@0.225.6",
+            "npm:@jsr/std__fs@0.229.3",
+            "npm:@jsr/std__log@~0.224.6",
+            "npm:@jsr/std__media-types@0.224.0",
+            "npm:@jsr/std__path@1.0.3",
+            "npm:@jsr/std__yaml@^1.0.5",
             "npm:@jsr/torm__sqlite@^1.9.7",
             "npm:@opentelemetry/api@1.9.0",
             "npm:@sveltejs/kit@2.43.7",
             "npm:@sveltejs/vite-plugin-svelte@6.2.1",
             "npm:@tailwindcss/vite@4.1.14",
+            "npm:@types/deno@^2.5.0",
             "npm:svelte-check@4.3.2",
             "npm:svelte@5.39.8",
             "npm:tailwindcss@4.1.14",
+            "npm:ts-pattern@5.2.0",
             "npm:typescript-svelte-plugin@0.3.50",
             "npm:typescript@5.9.3",
-            "npm:vite@7.1.8"
+            "npm:vite@7.1.8",
+            "npm:zod@4.1.11"
           ]
         }
       },

--- a/deno.lock
+++ b/deno.lock
@@ -66,10 +66,13 @@
     "jsr:@std/yaml@^1.0.5": "1.0.9",
     "jsr:@torm/sqlite@^1.9.7": "1.9.7",
     "npm:@deno/vite-plugin@1.0.6": "1.0.6_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@jsr/andykais__ts-rpc@~0.2.2": "0.2.4_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:@jsr/andykais__ts-rpc@~0.2.4": "0.2.4_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@jsr/cliffy__command@1.0.0-rc.8": "1.0.0-rc.8",
     "npm:@jsr/std__datetime@~0.225.3": "0.225.7",
     "npm:@jsr/std__fmt@0.225.6": "0.225.6",
     "npm:@jsr/std__fs@0.229.3": "0.229.3",
+    "npm:@jsr/std__http@0.224.5": "0.224.5",
     "npm:@jsr/std__log@~0.224.6": "0.224.14",
     "npm:@jsr/std__media-types@0.224.0": "0.224.0",
     "npm:@jsr/std__path@1.0.3": "1.0.3",
@@ -539,6 +542,38 @@
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/andykais__ts-rpc/0.2.4.tgz"
     },
+    "@jsr/cliffy__command@1.0.0-rc.8": {
+      "integrity": "sha512-ayYncuw/PTIiceKKMEZPyv9Qu39Pt6bNTBariKjZi0th5Je4am6RNC+FSXEAHPJBH+bAY3S0lwaFsEGC9uPEmg==",
+      "dependencies": [
+        "@jsr/cliffy__flags",
+        "@jsr/cliffy__internal",
+        "@jsr/cliffy__table",
+        "@jsr/std__fmt@1.0.10",
+        "@jsr/std__text"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/cliffy__command/1.0.0-rc.8.tgz"
+    },
+    "@jsr/cliffy__flags@1.0.0-rc.8": {
+      "integrity": "sha512-gbIPx2XIxkNlAQikraWm4h+C77tHmE8NQhwIX6Qn2rrU32uh/Vg4OXklXvlrkfrcs3wMbOd/SZ9e/wVqM0H8/w==",
+      "dependencies": [
+        "@jsr/std__text"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/cliffy__flags/1.0.0-rc.8.tgz"
+    },
+    "@jsr/cliffy__internal@1.0.0-rc.8": {
+      "integrity": "sha512-xKIMr2v5+R5qNw7CWqic2ulhZE3cXPKB40rb5mibsUrtJkC55Ha/3PGgTm1W9SWH1+IqA/FfC2ikpjzCXSKVBw==",
+      "dependencies": [
+        "@jsr/std__fmt@1.0.10"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/cliffy__internal/1.0.0-rc.8.tgz"
+    },
+    "@jsr/cliffy__table@1.0.0-rc.8": {
+      "integrity": "sha512-7r94r56TLd17raKyZQHV3/qLngy2Lusuy4rjA/5QMDNM0lDIwZw67lmRMxpyX6+qzAxzRAJ8dtTvFSvGwrSqgg==",
+      "dependencies": [
+        "@jsr/std__fmt@1.0.10"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/cliffy__table/1.0.0-rc.8.tgz"
+    },
     "@jsr/oak__commons@0.10.2": {
       "integrity": "sha512-E7aBj8qrfgPiAhmXCTpq/ZhErnlbMwsG6WO2cthuXrwEDl5pNf90nTi6Q/Jjw0ngC/9ElfueXmGEuWydhGYJBQ==",
       "dependencies": [
@@ -800,6 +835,10 @@
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/1.1.6.tgz"
     },
+    "@jsr/std__regexp@1.0.2": {
+      "integrity": "sha512-wvJnzBWsPW4YLdAhCSggh4NyNia/qtzsuJr0kSYuqUBtvOU/RsI/WKB5lu7ehlzuZ5Sy+efr0ACyogCCZmw0YQ==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__regexp/1.0.2.tgz"
+    },
     "@jsr/std__streams@0.223.0": {
       "integrity": "sha512-YfOfRTpnTocgC5h22aRMgu74ByBO6763PgwG2p7iFWYZFBRrDNW6WqYK1MFXcbU8VrwlgpUEvkS3Xk9dJnd+hw==",
       "dependencies": [
@@ -816,6 +855,13 @@
         "@jsr/std__io@0.224.9"
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__streams/0.224.5.tgz"
+    },
+    "@jsr/std__text@1.0.19": {
+      "integrity": "sha512-OIXUoD4gty+GH+ZOpe7LT1jVr+31ctOoIoxBzLN1m3fvAOtqWyEz6Ap3NwDiuEgHpAIMz/O5L2SKDr0F2bChCA==",
+      "dependencies": [
+        "@jsr/std__regexp"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__text/1.0.19.tgz"
     },
     "@jsr/std__yaml@1.1.2": {
       "integrity": "sha512-R2U09+AG6VgFet8qmVhkFw1eKQKeG54RAejd64G5F0XrzMFmHp6KOMnabOdSowd7kj28wFt/x4XT2ARGZEEeVw==",
@@ -1623,14 +1669,6 @@
           "dependencies": [
             "npm:@deno/vite-plugin@1.0.6",
             "npm:@jsr/andykais__ts-rpc@~0.2.4",
-            "npm:@jsr/std__datetime@~0.225.3",
-            "npm:@jsr/std__fmt@0.225.6",
-            "npm:@jsr/std__fs@0.229.3",
-            "npm:@jsr/std__log@~0.224.6",
-            "npm:@jsr/std__media-types@0.224.0",
-            "npm:@jsr/std__path@1.0.3",
-            "npm:@jsr/std__yaml@^1.0.5",
-            "npm:@jsr/torm__sqlite@^1.9.7",
             "npm:@opentelemetry/api@1.9.0",
             "npm:@sveltejs/kit@2.43.7",
             "npm:@sveltejs/vite-plugin-svelte@6.2.1",
@@ -1641,8 +1679,7 @@
             "npm:tailwindcss@4.1.14",
             "npm:typescript-svelte-plugin@0.3.50",
             "npm:typescript@5.9.3",
-            "npm:vite@7.1.8",
-            "npm:zod@4.1.11"
+            "npm:vite@7.1.8"
           ]
         }
       },

--- a/deno.lock
+++ b/deno.lock
@@ -1639,7 +1639,6 @@
             "npm:svelte-check@4.3.2",
             "npm:svelte@5.39.8",
             "npm:tailwindcss@4.1.14",
-            "npm:ts-pattern@5.2.0",
             "npm:typescript-svelte-plugin@0.3.50",
             "npm:typescript@5.9.3",
             "npm:vite@7.1.8",

--- a/packages/core/src/lib/file_processor.ts
+++ b/packages/core/src/lib/file_processor.ts
@@ -649,7 +649,12 @@ class FileProcessor {
   }
 
   async * #readlines(stream: ReadableStream<Uint8Array>) {
-    const reader = stream.pipeThrough(new TextDecoderStream()).getReader()
+    // TextDecoderStream types its writable side as WritableStream<BufferSource>, which
+    // TypeScript's DOM lib does not treat as assignable to the WritableStream<Uint8Array>
+    // that pipeThrough infers. The pairing is valid at runtime (a Uint8Array is a
+    // BufferSource), so bridge the lib-level mismatch explicitly.
+    const decoder = new TextDecoderStream() as ReadableWritablePair<string, Uint8Array>
+    const reader = stream.pipeThrough(decoder).getReader()
     let buffer = ''
     let read_result = await reader.read()
     while (!read_result.done) {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,19 +8,29 @@
 		"build": "vite build",
 		"build:local": "LOCAL_BUILD=true vite build",
 		"prepare": "svelte-kit sync || echo ''",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.svelte.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.svelte.json --watch"
 	},
 	"dependencies": {
 		"@andykais/ts-rpc": "npm:@jsr/andykais__ts-rpc@^0.2.4",
 		"@opentelemetry/api": "1.9.0",
-		"@torm/sqlite": "npm:@jsr/torm__sqlite@^1.9.7"
+		"@std/datetime": "npm:@jsr/std__datetime@^0.225.3",
+		"@std/fmt": "npm:@jsr/std__fmt@0.225.6",
+		"@std/fs": "npm:@jsr/std__fs@0.229.3",
+		"@std/log": "npm:@jsr/std__log@^0.224.6",
+		"@std/media-types": "npm:@jsr/std__media-types@0.224.0",
+		"@std/path": "npm:@jsr/std__path@1.0.3",
+		"@std/yaml": "npm:@jsr/std__yaml@^1.0.5",
+		"@torm/sqlite": "npm:@jsr/torm__sqlite@^1.9.7",
+		"ts-pattern": "npm:ts-pattern@5.2.0",
+		"zod": "npm:zod@4.1.11"
 	},
 	"devDependencies": {
 		"@deno/vite-plugin": "1.0.6",
 		"@sveltejs/kit": "2.43.7",
 		"@sveltejs/vite-plugin-svelte": "6.2.1",
 		"@tailwindcss/vite": "4.1.14",
+		"@types/deno": "^2.5.0",
 		"svelte": "5.39.8",
 		"svelte-check": "4.3.2",
 		"tailwindcss": "4.1.14",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,16 +13,7 @@
 	},
 	"dependencies": {
 		"@andykais/ts-rpc": "npm:@jsr/andykais__ts-rpc@^0.2.4",
-		"@opentelemetry/api": "1.9.0",
-		"@std/datetime": "npm:@jsr/std__datetime@^0.225.3",
-		"@std/fmt": "npm:@jsr/std__fmt@0.225.6",
-		"@std/fs": "npm:@jsr/std__fs@0.229.3",
-		"@std/log": "npm:@jsr/std__log@^0.224.6",
-		"@std/media-types": "npm:@jsr/std__media-types@0.224.0",
-		"@std/path": "npm:@jsr/std__path@1.0.3",
-		"@std/yaml": "npm:@jsr/std__yaml@^1.0.5",
-		"@torm/sqlite": "npm:@jsr/torm__sqlite@^1.9.7",
-		"zod": "npm:zod@4.1.11"
+		"@opentelemetry/api": "1.9.0"
 	},
 	"devDependencies": {
 		"@deno/vite-plugin": "1.0.6",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,7 +22,6 @@
 		"@std/path": "npm:@jsr/std__path@1.0.3",
 		"@std/yaml": "npm:@jsr/std__yaml@^1.0.5",
 		"@torm/sqlite": "npm:@jsr/torm__sqlite@^1.9.7",
-		"ts-pattern": "npm:ts-pattern@5.2.0",
 		"zod": "npm:zod@4.1.11"
 	},
 	"devDependencies": {

--- a/packages/web/src/app.d.ts
+++ b/packages/web/src/app.d.ts
@@ -1,9 +1,15 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+import type { Forager } from '@forager/core'
+import type { Config } from '$lib/server/config.ts'
+
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			forager: Forager
+			config: Config
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -29,8 +29,10 @@ if (!building) {
     forager.init()
   } else {
     if (env.FORAGER_INSTANCE) {
-      forager = env.FORAGER_INSTANCE
-      config = env.FORAGER_CONFIG
+      // In production the CLI injects a live Forager instance and parsed config
+      // through these env slots, so they are not the plain strings $env types them as.
+      forager = env.FORAGER_INSTANCE as unknown as Forager
+      config = env.FORAGER_CONFIG as unknown as Config
     } else {
       throw new Error(`FORAGER_INSTANCE must be passed to sveltekit hooks`)
     }

--- a/packages/web/src/lib/actions/focusable.ts
+++ b/packages/web/src/lib/actions/focusable.ts
@@ -1,11 +1,15 @@
-export function focusable(node: HTMLElement) {
+export function focusable(node: HTMLElement, focused: boolean) {
+  const apply = (should_focus: boolean) => {
+    if (should_focus) {
+      node.focus()
+    } else {
+      node.blur()
+    }
+  }
+  apply(focused)
   return {
-    update(focused: boolean) {
-      if (focused) {
-        node.focus()
-      } else {
-        node.blur()
-      }
+    update(should_focus: boolean) {
+      apply(should_focus)
     }
   }
 

--- a/packages/web/src/lib/actions/scrollable.ts
+++ b/packages/web/src/lib/actions/scrollable.ts
@@ -1,4 +1,4 @@
-export function scrollable(node: HTMLElement) {
+export function scrollable(node: HTMLElement, _focused: boolean) {
   let is_visible = false
   const observer = new IntersectionObserver((entries) => {
     is_visible = entries[0].isIntersecting

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -18,11 +18,37 @@ class ForagerTagApi extends rpc.ApiController<Context> {
   parent_delete = this.context.forager.tag.parent_delete
 }
 
+class ForagerMediaApi extends rpc.ApiController<Context> {
+  create = this.context.forager.media.create
+  update = this.context.forager.media.update
+  upsert = this.context.forager.media.upsert
+  delete = this.context.forager.media.delete
+  search = this.context.forager.media.search
+  group = this.context.forager.media.group
+  get = this.context.forager.media.get
+  thumbnail = this.context.forager.media.thumbnail
+  reload = this.context.forager.media.reload
+}
+
+class ForagerSeriesApi extends rpc.ApiController<Context> {
+  create = this.context.forager.series.create
+  update = this.context.forager.series.update
+  upsert = this.context.forager.series.upsert
+  add = this.context.forager.series.add
+  get = this.context.forager.series.get
+  search = this.context.forager.series.search
+}
+
+class ForagerViewsApi extends rpc.ApiController<Context> {
+  start = this.context.forager.views.start
+  update = this.context.forager.views.update
+}
+
 class ForagerApi extends rpc.ApiController<Context> {
-  media = this.context.forager.media
-  series = this.context.forager.series
+  media = this.module(ForagerMediaApi)
+  series = this.module(ForagerSeriesApi)
   tag = this.module(ForagerTagApi)
-  views = this.context.forager.views
+  views = this.module(ForagerViewsApi)
 
 }
 

--- a/packages/web/src/lib/base_controller.ts
+++ b/packages/web/src/lib/base_controller.ts
@@ -26,8 +26,6 @@ abstract class BaseController {
     if (this.#config) return this.#config
     else throw new Error(`Controller::config not initialized`)
   }
-
-  abstract handlers: {}
 }
 
 export { BaseController }

--- a/packages/web/src/lib/components/Header.svelte
+++ b/packages/web/src/lib/components/Header.svelte
@@ -8,6 +8,7 @@
     ...props
   }: {
     title: string
+    height?: number
     children: SvelteHTMLElements['div']['children']
   } = $props()
 

--- a/packages/web/src/lib/components/SelectInput.svelte
+++ b/packages/web/src/lib/components/SelectInput.svelte
@@ -4,7 +4,7 @@
     value: string
   }
   interface Props {
-    label: string
+    label?: string
     options: SelectOption[]
     value: string
     onchange?: (e: Event) => void

--- a/packages/web/src/lib/components/SelectInput.svelte
+++ b/packages/web/src/lib/components/SelectInput.svelte
@@ -5,9 +5,9 @@
   }
   interface Props {
     label: string
-    options: SelectOption
+    options: SelectOption[]
     value: string
-    onchange: () => void | undefined
+    onchange?: (e: Event) => void
   }
   let {
     label,

--- a/packages/web/src/lib/components/StarInput.svelte
+++ b/packages/web/src/lib/components/StarInput.svelte
@@ -5,16 +5,16 @@
 
   let {
     star,
-    value = $bindable<number>(),
+    value = $bindable<number | undefined>(),
     onclick,
   }: {
     star: number
-    value: number
+    value: number | undefined
     onclick: () => void
   } = $props()
 
   let icon_color = $derived.by(() => {
-    if (value >= star) {
+    if ((value ?? 0) >= star) {
       // starred
       return theme.colors.gray[400]
     } else {

--- a/packages/web/src/lib/components/Tag.svelte
+++ b/packages/web/src/lib/components/Tag.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import type { Forager } from '@forager/core'
+  import type { model_types } from '@forager/core'
 	import type { ClassValue } from 'svelte/elements';
   import * as parsers from '$lib/parsers.ts'
 
-  type Tag = ReturnType<Forager['tag']['search']>['results'][0]
+  type Tag = model_types.Tag
   let props: {tag: Tag, transparent?: boolean; show_group?: boolean; hide_count?: boolean; class?: ClassValue} = $props()
 
   const tag_identifier = props.tag.group === '' || props.show_group === false

--- a/packages/web/src/lib/components/TagAutoCompleteInput.svelte
+++ b/packages/web/src/lib/components/TagAutoCompleteInput.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import * as parsers from '$lib/parsers.ts'
-  import type { Forager } from '@forager/core'
+  import type { Forager, inputs } from '@forager/core'
   import type { BaseController } from "$lib/base_controller.ts";
   import Tag from '$lib/components/Tag.svelte'
 
   const debounce = <Args>(fn: (...args: Args[]) => void, pause: number) => {
-    let timer: number | undefined
+    let timer: ReturnType<typeof setTimeout> | undefined
     return (...args: Args[]) => {
       clearTimeout(timer)
       timer = setTimeout(() => {
@@ -46,7 +46,7 @@
       this.#last_query_hash = current_query_hash
 
       // TODO only do this when the query has changed. Currently any time we focus in/out of the browser tab, it will re-search
-      const search_options = {query:{tag_match}, sort_by}
+      const search_options: Parameters<typeof controller.client.forager.tag.search>[0] = {query:{tag_match}, sort_by}
       if (contextual_query) {
         search_options.contextual_query = contextual_query
       }
@@ -101,7 +101,7 @@
     input_classes?: string
     allow_multiple_tags?: boolean
     // NOTE contextual_query works, but it is too slow on large tag/media_reference databases, so we need to rethink this
-    contextual_query?: {}
+    contextual_query?: inputs.PaginatedSearch['query']
   } = $props()
 
   let root_element: HTMLDivElement
@@ -116,7 +116,7 @@
     text_position: 0,
     current_hover_selection_index: -1,
 
-    suggestion_buttons: [],
+    suggestion_buttons: [] as (HTMLButtonElement | null)[],
   })
 
   const tag_suggestions = new TagSuggestions()
@@ -139,7 +139,7 @@
         const length = tag_suggestions.state.length
         const index = input_state.current_hover_selection_index
         input_state.current_hover_selection_index = (index + 1) % length
-        input_state.suggestion_buttons[input_state.current_hover_selection_index].focus()
+        input_state.suggestion_buttons[input_state.current_hover_selection_index]?.focus()
       }
     },
     PrevTagSuggestion: e => {
@@ -147,7 +147,7 @@
         const length = tag_suggestions.state.length
         const index = input_state.current_hover_selection_index
         input_state.current_hover_selection_index = (index - 1 + length) % length
-        input_state.suggestion_buttons[input_state.current_hover_selection_index].focus()
+        input_state.suggestion_buttons[input_state.current_hover_selection_index]?.focus()
       }
     },
     Escape: e => {
@@ -185,7 +185,7 @@
     bind:this={input_element}
     list="taglist"
     onselectionchange={async e => {
-      input_state.text_position = e.target.selectionStart
+      input_state.text_position = e.currentTarget.selectionStart ?? 0
       input_state.lost_focus = false
       tag_suggestions.refresh()
       // await get_tag_suggestions_debounced(e.target.value, e.target.selectionStart)
@@ -193,7 +193,7 @@
     oninput={async e => {
       input_state.show_suggestions = true
       input_state.lost_focus = false
-      search_string = e.target.value
+      search_string = e.currentTarget.value
       tag_suggestions.refresh()
     }}
     onfocusin={async e => {
@@ -211,11 +211,11 @@
       tag_suggestions.refresh()
     }}
     onfocusout={(e: FocusEvent) => {
-      if (suggestions_element && suggestions_element.contains(e.relatedTarget)) {
+      if (suggestions_element && suggestions_element.contains(e.relatedTarget as Node | null)) {
       } else {
         input_state.show_suggestions = false
       }
-      controller.runes.focus.pop('TagAutoCompleteInput', kind)
+      controller.runes.focus.pop({component: 'TagAutoCompleteInput', focus: kind})
       input_state.lost_focus = true
     }}
     value={search_string}

--- a/packages/web/src/lib/keybinds.ts
+++ b/packages/web/src/lib/keybinds.ts
@@ -22,7 +22,8 @@ type KeybindAction =
   | 'Star4'
   | 'Star5'
 
-type KeybindActionListener = (e: KeyboardEvent) => void
+export type KeybindActionEvent = CustomEvent<{ data: { keyboard_event: KeyboardEvent } }>
+type KeybindActionListener = (e: KeybindActionEvent) => void
 
 export class Keybinds {
   public emitter: EventTarget

--- a/packages/web/src/lib/keybinds.ts
+++ b/packages/web/src/lib/keybinds.ts
@@ -5,6 +5,9 @@ import type { Config } from '$lib/server/config.ts'
 type KeybindAction =
   | 'Escape'
   | 'Search'
+  | 'OpenMedia'
+  | 'CopyMedia'
+  | 'AddTag'
   | 'PrevMedia'
   | 'NextMedia'
   | 'PrevTagSuggestion'
@@ -55,12 +58,14 @@ export class Keybinds {
   }
 
   public listen(event: KeybindAction, handler: KeybindActionListener) {
-    this.emitter.addEventListener(event, handler)
+    // keybind handlers receive the KeyboardEvent dispatched via CustomEvent detail,
+    // but the DOM addEventListener signature is typed against the base Event.
+    this.emitter.addEventListener(event, handler as EventListener)
     return handler
   }
 
   public remove_listener(event: KeybindAction, handler: KeybindActionListener) {
-    this.emitter.removeEventListener(event, handler)
+    this.emitter.removeEventListener(event, handler as EventListener)
   }
 
   public handler = (e: KeyboardEvent) => {

--- a/packages/web/src/lib/parsers.ts
+++ b/packages/web/src/lib/parsers.ts
@@ -1,8 +1,10 @@
-import type { Forager } from '@forager/core'
-type TagModel = Awaited<ReturnType<Forager['tag']['search']>>['results'][0]
+interface TagEncodable {
+  group?: string | null
+  name: string
+}
 
 class Tag {
-  static encode(tag: TagModel) {
+  static encode(tag: TagEncodable) {
     if (tag.group) {
       return `${tag.group}:${tag.name}`
     } else {

--- a/packages/web/src/lib/runes/base_queryparams.svelte.ts
+++ b/packages/web/src/lib/runes/base_queryparams.svelte.ts
@@ -18,10 +18,10 @@ export abstract class BaseQueryParams<TParams extends Record<string, any>> exten
   public draft: TParams = $state() as TParams
   public current_serialized: string = '?'
 
-  constructor(client: BaseController['client']) {
+  constructor(client: BaseController['client'], defaults: TParams) {
     super(client)
-    this.current = { ...this.DEFAULTS }
-    this.draft = { ...this.DEFAULTS }
+    this.current = { ...defaults }
+    this.draft = { ...defaults }
 
     onMount(async () => {
       const params = this.parse_url(new URL(window.location.toString()))

--- a/packages/web/src/lib/runes/media_list_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_list_rune.svelte.ts
@@ -1,7 +1,12 @@
 import {Rune} from '$lib/runes/rune.ts'
-import type { Forager, MediaResponse, outputs } from '@forager/core'
+import type { Forager, MediaResponse, MediaGroupResponse, inputs } from '@forager/core'
 import { MediaViewRune } from '.'
+import type { AnyMediaViewRune } from '.'
 
+
+type AnyMediaResponse = MediaResponse | MediaGroupResponse
+
+type GroupSearchParams = Parameters<Forager['media']['group']>[0]
 
 type Result =
   | ReturnType<Forager['media']['search']>
@@ -27,12 +32,12 @@ export type Input =
 interface MediaListState {
   loading: boolean
   content: Result | null
-  results: MediaViewRune[]
+  results: AnyMediaViewRune[]
 }
 
 export class MediaListRune extends Rune {
-  #saved_params_type: 'media' | 'group_by' = 'media'
-  #saved_params: {} | undefined
+  #saved_params_type: Input['type'] = 'media'
+  #saved_params: Partial<GroupSearchParams> = {}
   #prev_query_hash: string = ''
   #fetch_count = 0
   #has_more = true
@@ -47,7 +52,7 @@ export class MediaListRune extends Rune {
 
   get content(): Result | null { return this.#state.content }
 
-  get results(): Result['results'] { return this.#state.results }
+  get results(): AnyMediaViewRune[] { return this.#state.results }
 
   get total() { return this.#state.content?.total ?? 0 }
 
@@ -73,26 +78,26 @@ export class MediaListRune extends Rune {
     this.#fetch_count ++
     this.#state.loading = true
 
-    let fetch_params: Input['params'] | undefined = this.#saved_params
+    let fetch_params: Partial<GroupSearchParams> = this.#saved_params
     if (this.#cursor !== undefined) {
-      fetch_params = {...fetch_params, cursor: this.#cursor} as any
+      fetch_params = {...fetch_params, cursor: this.#cursor}
     }
 
     const params_type = params?.type ?? this.#saved_params_type
     this.#saved_params_type = params_type
     let content: Result
     if (params_type === 'media') {
-      content = await this.client.forager.media.search(fetch_params)
+      content = await this.client.forager.media.search(fetch_params as inputs.PaginatedSearch)
     }
     else if (params_type === 'group_by') {
       fetch_params.limit = fetch_params.limit ?? 30
-      content = await this.client.forager.media.group(fetch_params)
+      content = await this.client.forager.media.group(fetch_params as GroupSearchParams)
     } else {
       throw new Error('unimplemented')
     }
 
-    const results = content.results.map(result => {
-      return MediaViewRune.create(this.client, result, fetch_params)
+    const results = (content.results as AnyMediaResponse[]).map(result => {
+      return MediaViewRune.create(this.client, result, fetch_params as GroupSearchParams)
     })
 
     this.#cursor = content.cursor
@@ -112,7 +117,7 @@ export class MediaListRune extends Rune {
     }
   }
 
-  async fetch_tag_summary(params: Input) {
+  async fetch_tag_summary(params?: Input) {
     // NOTE this currently just does a "union". We want an "intersection" for this view. Otherwise our default view returns all tags!
     /*
 

--- a/packages/web/src/lib/runes/media_list_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_list_rune.svelte.ts
@@ -60,7 +60,7 @@ export class MediaListRune extends Rune {
     this.#has_more = true
     this.#cursor = undefined
     this.#fetch_count = 0
-    this.#saved_params = undefined
+    this.#saved_params = {}
     this.#state = {
       loading: false,
       results: [],

--- a/packages/web/src/lib/runes/media_list_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_list_rune.svelte.ts
@@ -1,12 +1,10 @@
 import {Rune} from '$lib/runes/rune.ts'
 import type { Forager, MediaResponse, MediaGroupResponse, inputs } from '@forager/core'
 import { MediaViewRune } from '.'
-import type { AnyMediaViewRune } from '.'
+import type { AnyMediaViewRune, MediaSearchInput } from '.'
 
 
 type AnyMediaResponse = MediaResponse | MediaGroupResponse
-
-type GroupSearchParams = Parameters<Forager['media']['group']>[0]
 
 type Result =
   | ReturnType<Forager['media']['search']>
@@ -37,7 +35,7 @@ interface MediaListState {
 
 export class MediaListRune extends Rune {
   #saved_params_type: Input['type'] = 'media'
-  #saved_params: Partial<GroupSearchParams> = {}
+  #saved_params: MediaSearchInput = {}
   #prev_query_hash: string = ''
   #fetch_count = 0
   #has_more = true
@@ -78,7 +76,7 @@ export class MediaListRune extends Rune {
     this.#fetch_count ++
     this.#state.loading = true
 
-    let fetch_params: Partial<GroupSearchParams> = this.#saved_params
+    let fetch_params: MediaSearchInput = this.#saved_params
     if (this.#cursor !== undefined) {
       fetch_params = {...fetch_params, cursor: this.#cursor}
     }
@@ -91,13 +89,13 @@ export class MediaListRune extends Rune {
     }
     else if (params_type === 'group_by') {
       fetch_params.limit = fetch_params.limit ?? 30
-      content = await this.client.forager.media.group(fetch_params as GroupSearchParams)
+      content = await this.client.forager.media.group(fetch_params as inputs.PaginatedSearchGroupBy)
     } else {
       throw new Error('unimplemented')
     }
 
     const results = (content.results as AnyMediaResponse[]).map(result => {
-      return MediaViewRune.create(this.client, result, fetch_params as GroupSearchParams)
+      return MediaViewRune.create(this.client, result, fetch_params)
     })
 
     this.#cursor = content.cursor

--- a/packages/web/src/lib/runes/media_view_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_view_rune.svelte.ts
@@ -59,7 +59,7 @@ export class MediaViewRune extends Rune {
     throw new Error(`thumbnails are not available on ${this.media.media_type} responses`)
   }
 
-  public update(media_info: inputs.MediaInfo, tags: inputs.MediaReferenceUpdateTags) {
+  public update(media_info?: inputs.MediaInfo, tags?: inputs.MediaReferenceUpdateTags) {
     throw new Error('requires override')
   }
 
@@ -104,7 +104,7 @@ export class MediaViewRune extends Rune {
 export class MediaFileRune extends MediaViewRune {
   media_type  = 'media_file' as const satisfies MediaResponse['media_type']
 
-  public override async update(media_info: inputs.MediaInfo, tags: inputs.MediaReferenceUpdateTags) {
+  public override async update(media_info?: inputs.MediaInfo, tags?: inputs.MediaReferenceUpdateTags) {
     const updated = await this.client.forager.media.update(
       this.media_reference.id,
       media_info,
@@ -120,7 +120,7 @@ export class MediaFileRune extends MediaViewRune {
   }
 
   public img_fit_classes() {
-    if (this.media_file.width > this.media_file.height) {
+    if ((this.media_file.width ?? 0) > (this.media_file.height ?? 0)) {
       // its long edge is wide
       return "w-full"
     } else {
@@ -204,7 +204,7 @@ export class MediaGroupRune extends MediaViewRune {
       return "w-full h-full"
     } else {
       const media = this.grouped_state.media_list[0]
-      if (media.media_type === 'media_file' && media.media_file.width > media.media_file.height) {
+      if (media.media_type === 'media_file' && (media.media_file.width ?? 0) > (media.media_file.height ?? 0)) {
         // its long edge is wide
         return "w-full"
       } else {

--- a/packages/web/src/lib/runes/media_view_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_view_rune.svelte.ts
@@ -1,88 +1,94 @@
 import {Rune} from '$lib/runes/rune.ts'
-import type { MediaResponse, MediaGroupResponse, Forager, inputs, model_types } from '@forager/core'
+import type { MediaResponse, MediaFileResponse, MediaSeriesResponse, MediaGroupResponse, Forager, inputs, model_types } from '@forager/core'
 import type { BaseController } from '$lib/base_controller.ts'
 
 
 type AnyMediaResponse = MediaResponse | MediaGroupResponse
 
-type GroupSearchParams = Parameters<Forager['media']['group']>[0]
+/**
+ * The search/group params that produced a given result. These are threaded straight
+ * through from the media list without favoring one search variant over another; the
+ * rune that needs them (the grouped rune) narrows to the shape it requires.
+ */
+export type MediaSearchInput =
+  | NonNullable<Parameters<Forager['media']['search']>[0]>
+  | Parameters<Forager['media']['group']>[0]
 
-interface State {
-  media: AnyMediaResponse
+
+interface State<M extends AnyMediaResponse> {
+  media: M
   full_thumbnails: MediaResponse['thumbnails'] | undefined
 }
 
 
-export class MediaViewRune extends Rune {
-  media_type!: AnyMediaResponse['media_type']
-  state = $state<State>()
+/**
+ * Base class for a single item rendered in the media list. The data getters and
+ * mutations below are only meaningful for the media types that actually carry the
+ * relevant data, so the base implementations error and each subclass overrides the
+ * ones it supports.
+ */
+export abstract class MediaViewRune<M extends AnyMediaResponse = AnyMediaResponse> extends Rune {
+  abstract media_type: M['media_type']
+  state = $state<State<M>>()
   current_view: model_types.View | undefined
 
-  protected constructor(client: BaseController['client'], media_response: AnyMediaResponse) {
+  protected constructor(client: BaseController['client'], media_response: M) {
     super(client)
     this.state = {
       media: media_response,
-      full_thumbnails: undefined
+      full_thumbnails: undefined,
     }
   }
 
-  get media() {
+  get media(): M {
     return this.state!.media
   }
 
-  set media(media: AnyMediaResponse) {
+  set media(media: M) {
     this.state!.media = media
   }
 
-  get tags() {
-    if ('tags' in this.media) return this.media.tags
-    throw new Error(`tags are not available on ${this.media.media_type} responses`)
+  get media_reference(): model_types.MediaReference {
+    throw new Error(`media_reference is not available on ${this.media_type} media`)
   }
 
-  get media_reference() {
-    if ('media_reference' in this.media) return this.media.media_reference
-    throw new Error(`media_reference is not available on ${this.media.media_type} responses`)
+  get tags(): model_types.Tag[] {
+    throw new Error(`tags are not available on ${this.media_type} media`)
   }
 
-  get media_file() {
-    if (this.media.media_type === 'media_file') return this.media.media_file
-    throw new Error(`media_file is not available on ${this.media.media_type} responses`)
+  get media_file(): model_types.MediaFile {
+    throw new Error(`media_file is not available on ${this.media_type} media`)
+  }
+
+  get thumbnails(): MediaResponse['thumbnails'] {
+    throw new Error(`thumbnails are not available on ${this.media_type} media`)
   }
 
   get preview_thumbnail(): string | undefined {
-    if ('thumbnails' in this.media) return `/files/thumbnail/${this.media.thumbnails.results.at(0)?.id}`
-    return undefined
+    throw new Error(`preview_thumbnail is not available on ${this.media_type} media`)
   }
 
-  get thumbnails() {
-    if ('thumbnails' in this.media) return this.media.thumbnails
-    throw new Error(`thumbnails are not available on ${this.media.media_type} responses`)
+  public update(media_info?: inputs.MediaInfo, tags?: inputs.MediaReferenceUpdateTags): Promise<void> {
+    throw new Error(`update is not available on ${this.media_type} media`)
   }
 
-  public update(media_info?: inputs.MediaInfo, tags?: inputs.MediaReferenceUpdateTags) {
-    throw new Error('requires override')
+  public star(stars: number): Promise<void> {
+    throw new Error(`star is not available on ${this.media_type} media`)
   }
 
-  public async star(stars: number) {
-    const updated = await this.client.forager.media.update(
-      this.media_reference.id,
-      {stars}
-    )
-    this.media = updated
+  public add_view(): Promise<void> {
+    throw new Error(`add_view is not available on ${this.media_type} media`)
   }
 
-  public async load_detailed_view() {
-    throw new Error('requires override')
+  public load_detailed_view(): Promise<void> {
+    throw new Error(`load_detailed_view is not available on ${this.media_type} media`)
   }
 
-  public async add_view() {
-    // TODO track view and update it as a video loops, or as an image has stayed open for a while
-    const view_response = await this.client.forager.views.start({media_reference_id: this.media_reference.id })
-    this.current_view = view_response.view
-    this.media_reference.view_count = view_response.media_reference.view_count
+  public img_fit_classes(): string {
+    throw new Error(`img_fit_classes is not available on ${this.media_type} media`)
   }
 
-  static create(client: BaseController['client'], media_response: AnyMediaResponse, search_params: GroupSearchParams) {
+  static create(client: BaseController['client'], media_response: AnyMediaResponse, search_params: MediaSearchInput) {
     if (media_response.media_type === 'media_file') {
       return new MediaFileRune(client, media_response)
     } else if (media_response.media_type === 'media_series') {
@@ -93,16 +99,42 @@ export class MediaViewRune extends Rune {
       throw new Error(`Unexpected media_response ${JSON.stringify(media_response)}`)
     }
   }
-
-  public img_fit_classes(): string {
-    throw new Error('requires override')
-  }
-
 }
 
 
-export class MediaFileRune extends MediaViewRune {
-  media_type  = 'media_file' as const satisfies MediaResponse['media_type']
+/** Shared behavior for runes backed by a concrete media reference (files and series). */
+abstract class MediaReferenceRune<M extends MediaFileResponse | MediaSeriesResponse> extends MediaViewRune<M> {
+  override get media_reference(): model_types.MediaReference {
+    return this.media.media_reference
+  }
+
+  override get tags(): model_types.Tag[] {
+    return this.media.tags
+  }
+
+  override get thumbnails(): MediaResponse['thumbnails'] {
+    return this.media.thumbnails
+  }
+
+  override get preview_thumbnail(): string | undefined {
+    return `/files/thumbnail/${this.media.thumbnails.results.at(0)?.id}`
+  }
+
+  public override async add_view() {
+    // TODO track view and update it as a video loops, or as an image has stayed open for a while
+    const view_response = await this.client.forager.views.start({media_reference_id: this.media_reference.id })
+    this.current_view = view_response.view
+    this.media_reference.view_count = view_response.media_reference.view_count
+  }
+}
+
+
+export class MediaFileRune extends MediaReferenceRune<MediaFileResponse> {
+  media_type = 'media_file' as const
+
+  override get media_file(): model_types.MediaFile {
+    return this.media.media_file
+  }
 
   public override async update(media_info?: inputs.MediaInfo, tags?: inputs.MediaReferenceUpdateTags) {
     const updated = await this.client.forager.media.update(
@@ -113,13 +145,21 @@ export class MediaFileRune extends MediaViewRune {
     this.media = updated
   }
 
+  public override async star(stars: number) {
+    const updated = await this.client.forager.media.update(
+      this.media_reference.id,
+      {stars}
+    )
+    this.media = updated
+  }
+
   public override async load_detailed_view() {
     if (this.state!.full_thumbnails) return
     const result = await this.client.forager.media.get({media_reference_id: this.media_reference.id })
     this.state!.full_thumbnails = result.thumbnails
   }
 
-  public img_fit_classes() {
+  public override img_fit_classes() {
     if ((this.media_file.width ?? 0) > (this.media_file.height ?? 0)) {
       // its long edge is wide
       return "w-full"
@@ -131,8 +171,8 @@ export class MediaFileRune extends MediaViewRune {
 }
 
 
-export class MediaSeriesRune extends MediaViewRune {
-  media_type  = 'media_series' as const satisfies MediaResponse['media_type']
+export class MediaSeriesRune extends MediaReferenceRune<MediaSeriesResponse> {
+  media_type = 'media_series' as const
 
   public override async load_detailed_view() {
     if (this.state!.full_thumbnails) return
@@ -142,7 +182,7 @@ export class MediaSeriesRune extends MediaViewRune {
     // const series_items = await this.client.forager.media.search({query: {series_id: this.media_reference.id }})
   }
 
-  public img_fit_classes() {
+  public override img_fit_classes() {
     console.warn(`media series img fit functions are not implemented`)
     return "w-full"
   }
@@ -152,31 +192,30 @@ export class MediaSeriesRune extends MediaViewRune {
 interface GroupState {
   media_list: MediaResponse[]
 }
-export class MediaGroupRune extends MediaViewRune {
-  media_type  = 'grouped' as const
+export class MediaGroupRune extends MediaViewRune<MediaGroupResponse> {
+  media_type = 'grouped' as const
   grouped_state = $state<GroupState>({
     media_list: []
   })
 
-  constructor(client: BaseController['client'], media_response: MediaGroupResponse, search_params: GroupSearchParams) {
+  constructor(client: BaseController['client'], media_response: MediaGroupResponse, search_params: MediaSearchInput) {
     super(client, media_response)
 
-    const {group_by, cursor, ...merged_search_params} = search_params
-
-    if (group_by['tag_group'] !== undefined) {
-      merged_search_params.query = {...merged_search_params.query}
-      merged_search_params.query.tags = merged_search_params.query.tags
-          ? [...merged_search_params.query.tags]
-          : []
-      const tag = `${group_by.tag_group}:${media_response.group.value}`
-      merged_search_params.query.tags.push(tag)
-      if (merged_search_params.sort_by === 'count') {
-        merged_search_params.sort_by = 'created_at'
-      }
-      merged_search_params.limit = 1 // TODO until we implement a filmstrip render, we only need one image
-    } else {
+    if (!('group_by' in search_params) || search_params.group_by?.tag_group === undefined) {
       throw new Error(`unexpected search group`)
     }
+
+    const {group_by, cursor, ...merged_search_params} = search_params
+    merged_search_params.query = {...merged_search_params.query}
+    merged_search_params.query.tags = merged_search_params.query.tags
+        ? [...merged_search_params.query.tags]
+        : []
+    const tag = `${group_by.tag_group}:${media_response.group.value}`
+    merged_search_params.query.tags.push(tag)
+    if (merged_search_params.sort_by === 'count') {
+      merged_search_params.sort_by = 'created_at'
+    }
+    merged_search_params.limit = 1 // TODO until we implement a filmstrip render, we only need one image
 
     // `merged_search_params` is the group-by query with its grouping fields removed, so
     // it maps onto a standard media search that fetches the media under this group.
@@ -187,11 +226,10 @@ export class MediaGroupRune extends MediaViewRune {
   }
 
   get group_metadata() {
-    if (this.media.media_type === 'grouped') return this.media.group
-    throw new Error(`group metadata is not available on ${this.media.media_type} responses`)
+    return this.media.group
   }
 
-  get preview_thumbnail(): string | undefined {
+  override get preview_thumbnail(): string | undefined {
     const media_entry = this.grouped_state.media_list.at(0)
     if (media_entry && 'thumbnails' in media_entry) {
       return `/files/thumbnail/${media_entry.thumbnails.results[0].id}`
@@ -199,7 +237,7 @@ export class MediaGroupRune extends MediaViewRune {
     return undefined
   }
 
-  public img_fit_classes() {
+  public override img_fit_classes() {
     if (this.grouped_state.media_list.length === 0) {
       return "w-full h-full"
     } else {

--- a/packages/web/src/lib/runes/media_view_rune.svelte.ts
+++ b/packages/web/src/lib/runes/media_view_rune.svelte.ts
@@ -1,22 +1,24 @@
 import {Rune} from '$lib/runes/rune.ts'
+import type { MediaResponse, MediaGroupResponse, Forager, inputs, model_types } from '@forager/core'
 import type { BaseController } from '$lib/base_controller.ts'
-import type { MediaResponse, inputs, type model_types } from '@forager/core'
 
+
+type AnyMediaResponse = MediaResponse | MediaGroupResponse
+
+type GroupSearchParams = Parameters<Forager['media']['group']>[0]
 
 interface State {
-  media: MediaResponse
+  media: AnyMediaResponse
   full_thumbnails: MediaResponse['thumbnails'] | undefined
 }
 
 
-interface SearchParams {}
-
 export class MediaViewRune extends Rune {
-  media_type!: MediaResponse['media_type'] | 'grouped'
+  media_type!: AnyMediaResponse['media_type']
   state = $state<State>()
-  current_view: model_types.View
+  current_view: model_types.View | undefined
 
-  protected constructor(client: BaseController['client'], media_response: MediaResponse) {
+  protected constructor(client: BaseController['client'], media_response: AnyMediaResponse) {
     super(client)
     this.state = {
       media: media_response,
@@ -28,28 +30,33 @@ export class MediaViewRune extends Rune {
     return this.state!.media
   }
 
-  set media(media: MediaResponse) {
-    return this.state!.media = media
+  set media(media: AnyMediaResponse) {
+    this.state!.media = media
   }
 
   get tags() {
-    return this.media.tags
+    if ('tags' in this.media) return this.media.tags
+    throw new Error(`tags are not available on ${this.media.media_type} responses`)
   }
 
   get media_reference() {
-    return this.media.media_reference
+    if ('media_reference' in this.media) return this.media.media_reference
+    throw new Error(`media_reference is not available on ${this.media.media_type} responses`)
   }
 
   get media_file() {
-    return this.media.media_file
+    if (this.media.media_type === 'media_file') return this.media.media_file
+    throw new Error(`media_file is not available on ${this.media.media_type} responses`)
   }
 
   get preview_thumbnail(): string | undefined {
-    return `/files/thumbnail/${this.media.thumbnails.results.at(0)?.id}`
+    if ('thumbnails' in this.media) return `/files/thumbnail/${this.media.thumbnails.results.at(0)?.id}`
+    return undefined
   }
 
   get thumbnails() {
-    return this.media.thumbnails
+    if ('thumbnails' in this.media) return this.media.thumbnails
+    throw new Error(`thumbnails are not available on ${this.media.media_type} responses`)
   }
 
   public update(media_info: inputs.MediaInfo, tags: inputs.MediaReferenceUpdateTags) {
@@ -72,10 +79,10 @@ export class MediaViewRune extends Rune {
     // TODO track view and update it as a video loops, or as an image has stayed open for a while
     const view_response = await this.client.forager.views.start({media_reference_id: this.media_reference.id })
     this.current_view = view_response.view
-    this.state.media.media_reference.view_count = view_response.media_reference.view_count
+    this.media_reference.view_count = view_response.media_reference.view_count
   }
 
-  static create(client: BaseController['client'], media_response: MediaResponse, search_params: SearchParams) {
+  static create(client: BaseController['client'], media_response: AnyMediaResponse, search_params: GroupSearchParams) {
     if (media_response.media_type === 'media_file') {
       return new MediaFileRune(client, media_response)
     } else if (media_response.media_type === 'media_series') {
@@ -87,7 +94,7 @@ export class MediaViewRune extends Rune {
     }
   }
 
-  public img_fit_classes() {
+  public img_fit_classes(): string {
     throw new Error('requires override')
   }
 
@@ -113,7 +120,7 @@ export class MediaFileRune extends MediaViewRune {
   }
 
   public img_fit_classes() {
-    if (this.media.media_file.width > this.media.media_file.height) {
+    if (this.media_file.width > this.media_file.height) {
       // its long edge is wide
       return "w-full"
     } else {
@@ -129,10 +136,10 @@ export class MediaSeriesRune extends MediaViewRune {
 
   public override async load_detailed_view() {
     if (this.state!.full_thumbnails) return
-    const series = await forager.series.get({series_id: media_response.media_reference.id })
+    const series = await this.client.forager.series.get({series_id: this.media_reference.id })
     this.state!.full_thumbnails = series.thumbnails
-    const series_items = await forager.media.search({query: {series_id: media_response.media_reference.id }})
     // TODO attach series items
+    // const series_items = await this.client.forager.media.search({query: {series_id: this.media_reference.id }})
   }
 
   public img_fit_classes() {
@@ -151,8 +158,7 @@ export class MediaGroupRune extends MediaViewRune {
     media_list: []
   })
 
-  protected constructor(client: BaseController['client'], media_response: MediaResponse, search_params: SearchParams) {
-    // debugger
+  constructor(client: BaseController['client'], media_response: MediaGroupResponse, search_params: GroupSearchParams) {
     super(client, media_response)
 
     const {group_by, cursor, ...merged_search_params} = search_params
@@ -172,19 +178,22 @@ export class MediaGroupRune extends MediaViewRune {
       throw new Error(`unexpected search group`)
     }
 
-    this.client.forager.media.search(merged_search_params)
-      .then((result: {}) => {
+    // `merged_search_params` is the group-by query with its grouping fields removed, so
+    // it maps onto a standard media search that fetches the media under this group.
+    this.client.forager.media.search(merged_search_params as inputs.PaginatedSearch)
+      .then(result => {
         this.grouped_state.media_list = result.results
       })
   }
 
   get group_metadata() {
-    return this.media.group
+    if (this.media.media_type === 'grouped') return this.media.group
+    throw new Error(`group metadata is not available on ${this.media.media_type} responses`)
   }
 
   get preview_thumbnail(): string | undefined {
     const media_entry = this.grouped_state.media_list.at(0)
-    if (media_entry) {
+    if (media_entry && 'thumbnails' in media_entry) {
       return `/files/thumbnail/${media_entry.thumbnails.results[0].id}`
     }
     return undefined
@@ -195,7 +204,7 @@ export class MediaGroupRune extends MediaViewRune {
       return "w-full h-full"
     } else {
       const media = this.grouped_state.media_list[0]
-      if (media.media_file.width > media.media_file.height) {
+      if (media.media_type === 'media_file' && media.media_file.width > media.media_file.height) {
         // its long edge is wide
         return "w-full"
       } else {
@@ -207,3 +216,4 @@ export class MediaGroupRune extends MediaViewRune {
 }
 
 export type MediaViewRunes = MediaSeriesRune | MediaFileRune
+export type AnyMediaViewRune = MediaFileRune | MediaSeriesRune | MediaGroupRune

--- a/packages/web/src/lib/runes/settings_rune.svelte.ts
+++ b/packages/web/src/lib/runes/settings_rune.svelte.ts
@@ -2,12 +2,18 @@ import type { Config } from '$lib/server/config.ts'
 import { Rune } from './rune';
 import type { BaseController } from '$lib/base_controller.ts'
 
-interface MutatableSettings {
+interface MutableSettings {
   'ui.media_list.thumbnail_size': Config['web']['ui_defaults']['media_list']['thumbnail_size']
   'ui.media_list.thumbnail_shape': Config['web']['ui_defaults']['media_list']['thumbnail_shape']
   'ui.search.advanced_filters.hide': Config['web']['ui_defaults']['search']['advanced_filters']['hide']
   'ui.sidebar.hide': Config['web']['ui_defaults']['sidebar']['hide']
 }
+
+
+type MutableSettingsUpdate = {
+  [K in keyof MutableSettings]: { path: K; value: MutableSettings[K] }
+}[keyof MutableSettings]
+
 
 export class SettingsRune extends Rune {
   #state = $state<Config>({} as Config);
@@ -28,22 +34,23 @@ export class SettingsRune extends Rune {
   // NOTE: TypeScript does not narrow `value`/return types against the switched
   // `path` because the generic `K` stays a union inside the body, so each branch
   // asserts the concrete setting type it operates on.
-  public set<K extends keyof MutatableSettings>(path: K, value: MutatableSettings[K]) {
-    switch(path) {
+  public set<K extends keyof MutableSettings>(path: K, value: MutableSettings[K]) {
+    const update = {path, value} as MutableSettingsUpdate
+    switch(update.path) {
       case 'ui.media_list.thumbnail_size': {
-        this.ui.media_list.thumbnail_size = value as MutatableSettings['ui.media_list.thumbnail_size']
+        this.ui.media_list.thumbnail_size = update.value
         break
       }
       case 'ui.media_list.thumbnail_shape': {
-        this.ui.media_list.thumbnail_shape = value as MutatableSettings['ui.media_list.thumbnail_shape']
+        this.ui.media_list.thumbnail_shape = update.value
         break
       }
       case 'ui.search.advanced_filters.hide': {
-        this.ui.search.advanced_filters.hide = value as MutatableSettings['ui.search.advanced_filters.hide']
+        this.ui.search.advanced_filters.hide = update.value
         break
       }
       case 'ui.sidebar.hide': {
-        this.ui.sidebar.hide = value as MutatableSettings['ui.sidebar.hide']
+        this.ui.sidebar.hide = update.value
         break
       }
       default: {
@@ -52,24 +59,24 @@ export class SettingsRune extends Rune {
     }
   }
 
-  public toggle<K extends keyof MutatableSettings>(path: K) {
+  public toggle<K extends keyof MutableSettings>(path: K) {
     const value = this.get(path)
     if (typeof value !== 'boolean') {
       throw new Error(`Unexpected value '${value}' for path '${path}'`)
     }
-    this.set(path, !value as MutatableSettings[K])
+    this.set(path, !value as MutableSettings[K])
   }
 
-  private get<K extends keyof MutatableSettings>(path: K): MutatableSettings[K] {
+  private get<K extends keyof MutableSettings>(path: K): MutableSettings[K] {
     switch(path) {
       case 'ui.media_list.thumbnail_size': {
-        return this.ui.media_list.thumbnail_size as MutatableSettings[K]
+        return this.ui.media_list.thumbnail_size as MutableSettings[K]
       }
       case 'ui.media_list.thumbnail_shape': {
-        return this.ui.media_list.thumbnail_shape as MutatableSettings[K]
+        return this.ui.media_list.thumbnail_shape as MutableSettings[K]
       }
       case 'ui.search.advanced_filters.hide': {
-        return this.ui.search.advanced_filters.hide as MutatableSettings[K]
+        return this.ui.search.advanced_filters.hide as MutableSettings[K]
       }
       default: {
         throw new Error(`Unexpected path '${path}'`)

--- a/packages/web/src/lib/runes/settings_rune.svelte.ts
+++ b/packages/web/src/lib/runes/settings_rune.svelte.ts
@@ -25,22 +25,25 @@ export class SettingsRune extends Rune {
     return this.#state.web.ui_defaults
   }
 
+  // NOTE: TypeScript does not narrow `value`/return types against the switched
+  // `path` because the generic `K` stays a union inside the body, so each branch
+  // asserts the concrete setting type it operates on.
   public set<K extends keyof MutatableSettings>(path: K, value: MutatableSettings[K]) {
     switch(path) {
       case 'ui.media_list.thumbnail_size': {
-        this.ui.media_list.thumbnail_size = value
+        this.ui.media_list.thumbnail_size = value as MutatableSettings['ui.media_list.thumbnail_size']
         break
       }
       case 'ui.media_list.thumbnail_shape': {
-        this.ui.media_list.thumbnail_shape = value
+        this.ui.media_list.thumbnail_shape = value as MutatableSettings['ui.media_list.thumbnail_shape']
         break
       }
       case 'ui.search.advanced_filters.hide': {
-        this.ui.search.advanced_filters.hide = value
+        this.ui.search.advanced_filters.hide = value as MutatableSettings['ui.search.advanced_filters.hide']
         break
       }
       case 'ui.sidebar.hide': {
-        this.ui.sidebar.hide = value
+        this.ui.sidebar.hide = value as MutatableSettings['ui.sidebar.hide']
         break
       }
       default: {
@@ -54,19 +57,19 @@ export class SettingsRune extends Rune {
     if (typeof value !== 'boolean') {
       throw new Error(`Unexpected value '${value}' for path '${path}'`)
     }
-    this.set(path, !value)
+    this.set(path, !value as MutatableSettings[K])
   }
 
   private get<K extends keyof MutatableSettings>(path: K): MutatableSettings[K] {
     switch(path) {
       case 'ui.media_list.thumbnail_size': {
-        return this.ui.media_list.thumbnail_size
+        return this.ui.media_list.thumbnail_size as MutatableSettings[K]
       }
       case 'ui.media_list.thumbnail_shape': {
-        return this.ui.media_list.thumbnail_shape
+        return this.ui.media_list.thumbnail_shape as MutatableSettings[K]
       }
       case 'ui.search.advanced_filters.hide': {
-        return this.ui.search.advanced_filters.hide
+        return this.ui.search.advanced_filters.hide as MutatableSettings[K]
       }
       default: {
         throw new Error(`Unexpected path '${path}'`)

--- a/packages/web/src/lib/runes/settings_rune.svelte.ts
+++ b/packages/web/src/lib/runes/settings_rune.svelte.ts
@@ -2,6 +2,10 @@ import type { Config } from '$lib/server/config.ts'
 import { Rune } from './rune';
 import type { BaseController } from '$lib/base_controller.ts'
 
+
+// Note that this file in general is weird. Svelte runes specifically need static accessors and static getters, so we cannot just have generic key/value accessors.
+// I landed on this design, where all the accessors are explicit. It looks unnecessary, but in practice its still ergonomic to use outside this module, and updating it is very straight forward.
+
 interface MutableSettings {
   'ui.media_list.thumbnail_size': Config['web']['ui_defaults']['media_list']['thumbnail_size']
   'ui.media_list.thumbnail_shape': Config['web']['ui_defaults']['media_list']['thumbnail_shape']
@@ -31,9 +35,6 @@ export class SettingsRune extends Rune {
     return this.#state.web.ui_defaults
   }
 
-  // NOTE: TypeScript does not narrow `value`/return types against the switched
-  // `path` because the generic `K` stays a union inside the body, so each branch
-  // asserts the concrete setting type it operates on.
   public set<K extends keyof MutableSettings>(path: K, value: MutableSettings[K]) {
     const update = {path, value} as MutableSettingsUpdate
     switch(update.path) {

--- a/packages/web/src/lib/server/config.ts
+++ b/packages/web/src/lib/server/config.ts
@@ -55,7 +55,7 @@ export const PackagesConfig = z.object({
         filmstrip: z.object({
           enabled: z.boolean().default(false),
             thumbnail_size: z.number().default(100),
-        }).strict().optional().transform(f => f ?? {enabled: false})
+        }).strict().optional().transform(f => f ?? {enabled: false, thumbnail_size: 100})
       }).strict().prefault({}),
     }).strict().prefault({}),
 

--- a/packages/web/src/lib/server/config.ts
+++ b/packages/web/src/lib/server/config.ts
@@ -54,8 +54,8 @@ export const PackagesConfig = z.object({
       media_view: z.object({
         filmstrip: z.object({
           enabled: z.boolean().default(false),
-            thumbnail_size: z.number().default(100),
-        }).strict().optional().transform(f => f ?? {enabled: false, thumbnail_size: 100})
+          thumbnail_size: z.number().default(100),
+        }).strict().prefault({})
       }).strict().prefault({}),
     }).strict().prefault({}),
 

--- a/packages/web/src/routes/browse/components/Footer.svelte
+++ b/packages/web/src/routes/browse/components/Footer.svelte
@@ -66,7 +66,7 @@
         max={500}
         value={runes.settings.ui.media_list.thumbnail_size}
         oninput={e => {
-          runes.settings.set('ui.media_list.thumbnail_size', e.target.value)
+          runes.settings.set('ui.media_list.thumbnail_size', Number(e.currentTarget.value))
         }}>
       <span>{runes.settings.ui.media_list.thumbnail_size}px</span>
     </div>

--- a/packages/web/src/routes/browse/components/MediaDetails.svelte
+++ b/packages/web/src/routes/browse/components/MediaDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as path from '@std/path'
-  import type { Forager } from '@forager/core'
+  import type { model_types } from '@forager/core'
   import Sidebar from '$lib/components/Sidebar.svelte'
   import MediaDetailEntry from './MediaDetailEntry.svelte'
   import TagAutoCompleteInput from '$lib/components/TagAutoCompleteInput.svelte'
@@ -16,7 +16,7 @@
 
   let new_tag_str = $state<string>('')
 
-  type TagRecord = ReturnType<Forager['tag']['search']>['results'][0]
+  type TagRecord = model_types.Tag
   let sorted_tags: [string, TagRecord[]][] = $derived.by(() => {
     const grouped_tags: Record<string, TagRecord[]> = {}
     media_selections.current_selection.media_response?.tags.map(t => {

--- a/packages/web/src/routes/browse/components/MediaView.svelte
+++ b/packages/web/src/routes/browse/components/MediaView.svelte
@@ -47,9 +47,9 @@
     }
   })
 
-  function video_loader(node: HTMLVideoElement) {
+  function video_loader(node: HTMLVideoElement, video_url: string | undefined) {
     return {
-      update(video_source_url: string) {
+      update(video_source_url: string | undefined) {
         animation_progress = 0
         node.load()
       }
@@ -109,7 +109,7 @@
             max={media_selections.current_selection.media_response.media_file.duration} value={animation_progress}></progress>
           {#if controller.runes.settings.ui.media_view.filmstrip.enabled}
             <div class="w-full flex flex-row justify-center gap-1 overflow-x-scroll" style="height: {controller.runes.settings.ui.media_view.filmstrip.thumbnail_size}px;">
-              {#each media_selections.current_selection.thumbnails.results as thumbnail, index}
+              {#each media_selections.current_selection.media_response.thumbnails.results as thumbnail, index}
                 <div class="h-full">
                   <img class="h-full" src="/files/thumbnail/{media_selections.current_selection.media_response.media_reference.id}?index={index}" alt="Thumbnail {index}"></div>
               {/each}

--- a/packages/web/src/routes/browse/components/MediaView.svelte
+++ b/packages/web/src/routes/browse/components/MediaView.svelte
@@ -8,6 +8,10 @@
   // TODO wire this into settings
   let show_controls = $state<boolean>(false);
 
+  let {controller}: Props = $props()
+  const {media_selections} = controller.runes
+  let paused = $state(false)
+
   controller.keybinds.component_listen({
     Escape: e => {
       dialog.close()
@@ -33,10 +37,6 @@
       }
     },
   })
-
-  let {controller}: Props = $props()
-  const {media_selections} = controller.runes
-  let paused = $state(false)
 
   let filmstrip_thumbnails
   let filmstrip_height = 50

--- a/packages/web/src/routes/browse/components/SearchLink.svelte
+++ b/packages/web/src/routes/browse/components/SearchLink.svelte
@@ -4,7 +4,7 @@
 
   interface Props {
     controller: BrowseController
-    params: Partial<BrowseController['runes']['queryparams']['DEFAULTS']>
+    params: BrowseController['runes']['queryparams']['DEFAULTS']
     class?: ClassValue
     title?: string
     children: SvelteHTMLElements['div']['children']

--- a/packages/web/src/routes/browse/components/SearchResults.svelte
+++ b/packages/web/src/routes/browse/components/SearchResults.svelte
@@ -54,7 +54,6 @@
   {#each media_list.results as result, result_index}
     <div>
       <div 
-        type="button"
         class="inline-flex items-center justify-center p-1
                outline-none"
         use:scrollable={media_selections.current_selection.result_index === result_index}
@@ -134,7 +133,7 @@
               </SearchLink>
               <span>{result.group_metadata.count}</span>
           {:else}
-            UNEXPECTED MEDIA TYPE {result.media_type}
+            UNEXPECTED MEDIA TYPE {(result as { media_type: string }).media_type}
           {/if}
         </div>
         </div>

--- a/packages/web/src/routes/browse/controller.ts
+++ b/packages/web/src/routes/browse/controller.ts
@@ -19,7 +19,7 @@ class BrowseController extends BaseController {
   public constructor(config: Config) {
     super(config)
 
-    const media_list_rune = new MediaListRune(this.client, this.settings)
+    const media_list_rune = new MediaListRune(this.client)
     this.runes = {
       media_list: media_list_rune,
       focus: create_focuser(),

--- a/packages/web/src/routes/browse/runes/media_selections.svelte.ts
+++ b/packages/web/src/routes/browse/runes/media_selections.svelte.ts
@@ -1,5 +1,4 @@
 import {Rune} from '$lib/runes/rune.ts'
-import type { Forager, MediaResponse } from '@forager/core'
 import type * as runes from '$lib/runes/index.ts'
 import type { BaseController } from '$lib/base_controller.ts'
 
@@ -26,13 +25,12 @@ export type ThumbnailSelections =
 
 export interface CurrentSelection {
   show: boolean
-  media_response: runes.MediaViewRunes | null
+  media_response: runes.AnyMediaViewRune | null
   result_index: number
 }
 
 const CURRENT_SELECTION_DEFAULTS: CurrentSelection = {
   show: false,
-  thumbnails: null,
   media_response: null,
   result_index: 0,
 }
@@ -40,7 +38,7 @@ export class MediaSelectionsRune extends Rune {
   #selected_thumbnails = $state<ThumbnailSelections>({type: 'none'})
   #current_selection = $state<CurrentSelection>({...CURRENT_SELECTION_DEFAULTS})
 
-  public constructor(client: BaseController['client'], media_list_rune: MediaListRune) {
+  public constructor(client: BaseController['client'], media_list_rune: runes.MediaListRune) {
     super(client)
   }
 
@@ -60,7 +58,7 @@ export class MediaSelectionsRune extends Rune {
     return false
   }
 
-  public async set_current_selection(media_response: runes.MediaViewRune, result_index: number) {
+  public async set_current_selection(media_response: runes.AnyMediaViewRune, result_index: number) {
     this.#current_selection.show
     if (this.is_currently_selected(media_response.media_reference.id)) {
       await this.open_media()
@@ -92,7 +90,7 @@ export class MediaSelectionsRune extends Rune {
     this.#current_selection.show = false
   }
 
-  public async next_media(results: MediaResponse[]) {
+  public async next_media(results: runes.AnyMediaViewRune[]) {
     let next_index = 0
     if (
       this.#selected_thumbnails.type === 'ids' && this.#selected_thumbnails.media_reference_ids.length <= 1
@@ -109,7 +107,7 @@ export class MediaSelectionsRune extends Rune {
     await this.view_media()
   }
 
-  async prev_media(results: MediaResponse[]) {
+  async prev_media(results: runes.AnyMediaViewRune[]) {
     let prev_index = 0
     if (
       this.#selected_thumbnails.type === 'ids' && this.#selected_thumbnails.media_reference_ids.length <= 1

--- a/packages/web/src/routes/browse/runes/queryparams.svelte.ts
+++ b/packages/web/src/routes/browse/runes/queryparams.svelte.ts
@@ -122,7 +122,7 @@ export class QueryParamsManager extends Rune {
     // Parse each param with type coercion
     if (search) {
       for (const [key, val] of search.entries()) {
-        const params_key: keyof SearchParams = URL_PARAM_MAP_REVERSED[key] ?? key
+        const params_key = (URL_PARAM_MAP_REVERSED[key as keyof SearchParamsReversed] ?? key) as keyof SearchParams
 
         if (params_key === 'search_string') {
           params.search_string = val.replaceAll(',', ' ')
@@ -152,13 +152,13 @@ export class QueryParamsManager extends Rune {
   /**
    * Serialize SearchParams to URL string (for SearchLink components)
    */
-  public serialize(params: SearchParams): string {
+  public serialize(params: SearchParams): string | null {
     const url_params = new Map<string, string>()
 
     // Only include non-default values
     for (const [key, value] of Object.entries(params)) {
       if (value !== DEFAULTS[key as keyof SearchParams] && value !== undefined) {
-        const param_name = URL_PARAM_MAP[key as keyof SearchParams] ?? key
+        const param_name = (URL_PARAM_MAP as Partial<Record<keyof SearchParams, string>>)[key as keyof SearchParams] ?? key
 
         // Special encoding for tags (preserve : and ,)
         if (key === 'search_string') {
@@ -199,7 +199,7 @@ export class QueryParamsManager extends Rune {
     const serialized = this.serialize(params)
 
     if (this.current_serialized !== serialized) {
-      this.current_serialized = serialized
+      this.current_serialized = serialized ?? ''
       this.current = { ...params }
       if (serialized) {
         pushState(serialized, {})
@@ -224,9 +224,7 @@ export class QueryParamsManager extends Rune {
 
     // Handle boolean and numeric filters
     if (params.unread_only) {
-      if (params.unread_only === 'true' || params.unread_only === true) {
-        query.unread = true
-      }
+      query.unread = true
     }
 
     if (params.stars !== undefined) {
@@ -292,7 +290,7 @@ export class QueryParamsManager extends Rune {
     const params = { ...this.current }
 
     for (const [key, val] of Object.entries(partial_params)) {
-      const params_key: keyof SearchParams = URL_PARAM_MAP_REVERSED[key] ?? key
+      const params_key = (URL_PARAM_MAP_REVERSED[key as keyof SearchParamsReversed] ?? key) as keyof SearchParams
 
       if (params_key === 'search_string') {
         // Merge tags instead of replacing

--- a/packages/web/src/routes/browse/runes/queryparams.svelte.ts
+++ b/packages/web/src/routes/browse/runes/queryparams.svelte.ts
@@ -130,6 +130,8 @@ export class QueryParamsManager extends Rune {
           params.stars = parseInt(val)
         } else if (params_key === 'filepath') {
           params.filepath = decodeURIComponent(val)
+        } else if (params_key === 'unread_only') {
+          params.unread_only = val === 'true'
         } else if (params_key === 'media_type') {
           if (MEDIA_TYPE_FILTER_VALUES.has(val as MediaTypeFilter)) {
             params.media_type = val as MediaTypeFilter

--- a/packages/web/src/routes/files/media_file/[id]/+server.ts
+++ b/packages/web/src/routes/files/media_file/[id]/+server.ts
@@ -29,6 +29,10 @@ export const GET: RequestHandler = async ({ params, request, locals }) => {
     throw err
   }
 
+  if (media.media_type !== 'media_file') {
+    throw error(404, 'Media reference is not a media file')
+  }
+
   const filepath = media.media_file.filepath
 
   // Security: Validate file path is within allowed directories

--- a/packages/web/src/routes/rpc/[signature]/+server.ts
+++ b/packages/web/src/routes/rpc/[signature]/+server.ts
@@ -5,7 +5,7 @@ import {Api} from '$lib/api.ts'
 
 
 // this adapter stores stateful information like realtime connections. It should be instantiated once and reused
-let API_SINGLETON: rpc.ServerAdapter | undefined
+let API_SINGLETON: rpc.SvektekitRouterFunction | undefined
 
 
 export const PUT: RequestHandler = async (params) => {
@@ -13,5 +13,5 @@ export const PUT: RequestHandler = async (params) => {
     const context = params.locals
     API_SINGLETON = rpc.adapt(Api, context)
   }
-  return await API_SINGLETON(params)
+  return await API_SINGLETON!(params)
 }

--- a/packages/web/src/routes/tags/[slug]/+page.svelte
+++ b/packages/web/src/routes/tags/[slug]/+page.svelte
@@ -17,7 +17,7 @@
   let parent_input = $state('')
 
   $effect(() => {
-    const slug = decodeURIComponent(page.params.slug)
+    const slug = decodeURIComponent(page.params.slug ?? '')
     controller.load(slug)
   })
 </script>
@@ -68,11 +68,11 @@
                 class="rounded-md py-1 px-3 text-slate-100 bg-gray-800 text-sm min-h-16"
                 bind:value={controller.draft.description}
               ></textarea>
-              <label class="text-slate-400 text-sm">Media</label>
+              <span class="text-slate-400 text-sm">Media</span>
               <span class="text-slate-300 text-sm"><Numeric number={controller.detail.tag.media_reference_count} /></span>
-              <label class="text-slate-400 text-sm">Unread</label>
+              <span class="text-slate-400 text-sm">Unread</span>
               <span class="text-slate-300 text-sm"><Numeric number={controller.detail.tag.unread_media_reference_count} /></span>
-              <label class="text-slate-400 text-sm">Created</label>
+              <span class="text-slate-400 text-sm">Created</span>
               <Datetime value={controller.detail.tag.created_at} class="text-slate-300 text-sm" />
             </div>
             <div class="flex gap-3 items-center">
@@ -148,7 +148,7 @@
             }
           }}>
             <div class="flex-grow">
-              <label class="text-slate-400 text-xs">Set this tag as an alias that hides the following tags:</label>
+              <span class="text-slate-400 text-xs">Set this tag as an alias that hides the following tags:</span>
               <TagAutoCompleteInput
                 {controller}
                 bind:search_string={alias_input}

--- a/packages/web/src/routes/tags/runes/queryparams.svelte.ts
+++ b/packages/web/src/routes/tags/runes/queryparams.svelte.ts
@@ -33,7 +33,7 @@ export class TagQueryParams extends BaseQueryParams<SearchParams> {
   get URL_PARAM_MAP() { return URL_PARAM_MAP }
 
   constructor(client: BaseController['client']) {
-    super(client)
+    super(client, DEFAULTS)
   }
 
   #build_search_options(params: SearchParams, limit: number) {

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -9,9 +9,6 @@ const config = {
 
 	kit: {
 		adapter: adapter(),
-    experimental: {
-      remoteFunctions: true,
-    },
     prerender: {
       crawl: false,
 			entries: []

--- a/packages/web/tsconfig.svelte.json
+++ b/packages/web/tsconfig.svelte.json
@@ -1,0 +1,36 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler",
+
+    "plugins": [{
+      "name": "typescript-svelte-plugin",
+      "enabled": true,
+      "assumeIsSvelteProject": true
+    }],
+
+    "allowImportingTsExtensions": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["../core/src/*"],
+      "@forager/core": ["../core/src/mod.ts"]
+    }
+	},
+  // `@forager/core` is resolved to its TypeScript source so svelte-check can infer
+  // types across the workspace, but the core package is excluded from the checked
+  // fileset since it is a Deno project that is type-checked separately.
+  "exclude": [
+    "../node_modules/**",
+    "../../node_modules/**",
+    "../core/**"
+  ]
+}

--- a/packages/web/tsconfig.svelte.json
+++ b/packages/web/tsconfig.svelte.json
@@ -11,6 +11,14 @@
 		"strict": true,
 		"moduleResolution": "bundler",
 
+    // `@forager/core` is a Deno project whose source is pulled into the program
+    // by the path mapping below. `verbatimModuleSyntax` is disabled so its
+    // (Deno-valid) value/type imports don't surface here, and `DOM.AsyncIterable`
+    // is added so async-iterable web streams (e.g. `for await (…of readable)`)
+    // type-check the same way they run under Deno.
+    "verbatimModuleSyntax": false,
+    "lib": ["esnext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
+
     "plugins": [{
       "name": "typescript-svelte-plugin",
       "enabled": true,
@@ -20,17 +28,26 @@
     "allowImportingTsExtensions": true,
 
     "baseUrl": ".",
+    // NOTE: `paths` fully replaces the mapping inherited from
+    // ./.svelte-kit/tsconfig.json (TypeScript does not merge `paths` across
+    // `extends`), so the SvelteKit `$lib`/`$app` aliases are re-declared here
+    // relative to this file's location, alongside the workspace aliases.
     "paths": {
       "~/*": ["../core/src/*"],
-      "@forager/core": ["../core/src/mod.ts"]
+      "@forager/core": ["../core/src/mod.ts"],
+      "$lib": ["./src/lib"],
+      "$lib/*": ["./src/lib/*"],
+      "$app/types": ["./.svelte-kit/types/index.d.ts"]
     }
 	},
   // `@forager/core` is resolved to its TypeScript source so svelte-check can infer
   // types across the workspace, but the core package is excluded from the checked
   // fileset since it is a Deno project that is type-checked separately.
   "exclude": [
+    "node_modules/**",
     "../node_modules/**",
     "../../node_modules/**",
+    "../core/**/*",
     "../core/**"
   ]
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -10,7 +10,7 @@ const monorepo_root = path.resolve(__dirname, '..', '..')
   * Note that npm depedencies like you may put into package.json like `npm:@jsr/torm__sqlite@^1.9.7` do _not_ work */
 function resolve_workspace_imports(workspace_package: string) {
   const package_root = path.join(monorepo_root, 'packages', workspace_package)
-  const denojson = JSON.parse(new TextDecoder().decode(Deno.readFileSync(path.join(package_root, 'deno.json'))))
+  const denojson: { imports: Record<string, string> } = JSON.parse(new TextDecoder().decode(Deno.readFileSync(path.join(package_root, 'deno.json'))))
   const resolved_imports: Record<string, string> = {}
 
   for (const [package_alias, specifier] of Object.entries(denojson.imports)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `deno task --cwd packages/web check` (svelte-check) pass with **0 errors, 0 warnings**, and adds it as a Typecheck step in Web CI so PRs get TypeScript coverage. Previous attempt: #51.

[svelte-check passing with 0 errors](https://cursor.com/agents/bc-d685190e-1359-4563-a5a1-a06d2619bc7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_check_output.log)

## The problem & plan

svelte-check runs `tsc`, which cannot resolve Deno-style imports (`@forager/core`, `@std/*`, `jsr:`) or the `Deno` global. With everything unresolved, most types collapsed to `any` and errors were *masked* (139 reported). The plan was:

1. **Fix module/global resolution first** — this is foundational and (expectedly) *raises* the error count as real types start resolving.
2. **Fix the genuine type errors** that surface, working from foundational modules (runes, controllers, RPC spec) out to leaf components.
3. **Enable the check in CI**.

Error trajectory: `139` (mostly-`any`, masked) → `242` (types resolving) → `0`.

## Key changes

**Type-resolution infrastructure**
- Added real `@std/*` JSR types, `zod`, `ts-pattern`, and `@types/deno` to `packages/web` deps so `tsc` resolves Deno imports and the `Deno` global.
- Added `tsconfig.svelte.json` mapping `@forager/core`/`~/*` to core source and re-declaring the SvelteKit `$lib`/`$app` aliases (TS does not merge `paths` across `extends`). Disabled `verbatimModuleSyntax` and added `DOM.AsyncIterable` so Deno-valid imports and async-iterable web streams type-check.
- Declared `App.Locals` (`forager`, `config`); removed the unused `kit.experimental.remoteFunctions`.

**Real type fixes (app code)**
- Modeled the media view runes as a discriminated union (`media_file`/`media_series`/`grouped`) with union-narrowing getters; fixed genuine bugs (undefined `forager`/`media_response` refs in `MediaSeriesRune`).
- Exposed `media`/`series`/`views` as ts-rpc modules so `InferSpec` resolves the client type (previously every `client.forager.*` chain was `never`).
- Narrowed `MediaResponse` before `.media_file` access in the file endpoint; corrected RPC route adapter typing, queryparams index/serialize typing, event/target typing in `TagAutoCompleteInput`, svelte `use:` action params, and misc component props/casts.
- One small, runtime-noop core change: a documented cast in `file_processor.ts` for a TS DOM-lib `TextDecoderStream`/`pipeThrough` variance quirk (valid at runtime under Deno).

**CI**
- Enabled the `Typecheck` (`deno task check`) step in `.github/workflows/web.yml`.

## Verification
- `deno task --cwd packages/web check` → 0 errors, 0 warnings, exit 0.
- `deno task --cwd packages/web build` → succeeds.
- `deno check packages/core/src/lib/file_processor.ts` → passes.
- Core test suite: the only failures are the pre-existing floating-point/ffmpeg-precision cases documented in `AGENTS.md` (unrelated to this change).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d685190e-1359-4563-a5a1-a06d2619bc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d685190e-1359-4563-a5a1-a06d2619bc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

