### PR TITLE
refactor(web): replace controller prop drilling with svelte context

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -66,26 +66,26 @@
     "jsr:@std/yaml@^1.0.5": "1.0.9",
     "jsr:@torm/sqlite@^1.9.7": "1.9.7",
     "npm:@deno/vite-plugin@1.0.6": "1.0.6_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:@jsr/andykais__ts-rpc@~0.2.4": "0.2.4_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@jsr/andykais__ts-rpc@~0.2.4": "0.2.4_svelte@5.56.4",
     "npm:@jsr/torm__sqlite@^1.9.7": "1.9.7",
     "npm:@opentelemetry/api@1.9.0": "1.9.0",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
-    "npm:@sveltejs/kit@2.43.7": "2.43.7_@opentelemetry+api@1.9.0_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_acorn@8.15.0_@types+node@24.2.0",
-    "npm:@sveltejs/kit@2.5.24": "2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:@sveltejs/vite-plugin-svelte@6.2.1": "6.2.1_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@sveltejs/kit@2.43.7": "2.43.7_@opentelemetry+api@1.9.0_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.56.4__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3",
+    "npm:@sveltejs/kit@2.5.24": "2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.56.4__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3",
+    "npm:@sveltejs/vite-plugin-svelte@6.2.1": "6.2.1_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3",
     "npm:@tailwindcss/vite@4.1.14": "4.1.14_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:@types/node@*": "24.2.0",
     "npm:esbuild@*": "0.25.10",
     "npm:path-to-regexp@6.2.1": "6.2.1",
     "npm:sv@*": "0.12.5",
     "npm:sv@latest": "0.12.5",
-    "npm:svelte-check@4.3.2": "4.3.2_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3",
-    "npm:svelte@5.39.8": "5.39.8_acorn@8.15.0",
-    "npm:svelte@~5.39.8": "5.39.8_acorn@8.15.0",
+    "npm:svelte-check@4.3.2": "4.3.2_svelte@5.56.4_typescript@5.9.3",
+    "npm:svelte@5.56.4": "5.56.4",
+    "npm:svelte@~5.39.8": "5.39.8",
     "npm:tailwindcss@4.1.14": "4.1.14",
     "npm:ts-expect@*": "1.3.0",
     "npm:ts-pattern@5.2.0": "5.2.0",
-    "npm:typescript-svelte-plugin@0.3.50": "0.3.50_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3",
+    "npm:typescript-svelte-plugin@0.3.50": "0.3.50_svelte@5.56.4",
     "npm:typescript@5.9.3": "5.9.3",
     "npm:vite@7.1.8": "7.1.8_@types+node@24.2.0_picomatch@4.0.3",
     "npm:zod@4.1.11": "4.1.11",
@@ -522,11 +522,11 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/andykais__ts-rpc@0.2.4_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
+    "@jsr/andykais__ts-rpc@0.2.4_svelte@5.56.4": {
       "integrity": "sha512-q8DSNIQLpPw/z+VcVcY+rrbRsmzZmw+bwopW4u95buXRLO/Bet8uYRddroAA8AI5zZkvuHJnxlNppwUmIFU5rA==",
       "dependencies": [
         "@jsr/oak__oak",
-        "@sveltejs/kit@2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0"
+        "@sveltejs/kit@2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.56.4__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3"
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/andykais__ts-rpc/0.2.4.tgz"
     },
@@ -877,13 +877,13 @@
     "@standard-schema/spec@1.0.0": {
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
-    "@sveltejs/acorn-typescript@1.0.6_acorn@8.15.0": {
-      "integrity": "sha512-4awhxtMh4cx9blePWl10HRHj8Iivtqj+2QdDCSMDzxG+XKa9+VCNupQuCuvzEhYPzZSrX+0gC+0lHA/0fFKKQQ==",
+    "@sveltejs/acorn-typescript@1.0.11_acorn@8.17.0": {
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
       "dependencies": [
         "acorn"
       ]
     },
-    "@sveltejs/kit@2.43.7_@opentelemetry+api@1.9.0_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_acorn@8.15.0_@types+node@24.2.0": {
+    "@sveltejs/kit@2.43.7_@opentelemetry+api@1.9.0_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.56.4__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3": {
       "integrity": "sha512-6trpyltB9XZNkM8cfVHG9U2urAH4NPD7UeO0wiBvZjD8gHj6w9bVeWnBQgnO8LPNpzOhSlwnZDk355OOAa/9Zw==",
       "dependencies": [
         "@opentelemetry/api",
@@ -901,7 +901,7 @@
         "sade",
         "set-cookie-parser",
         "sirv@3.0.2",
-        "svelte",
+        "svelte@5.56.4",
         "vite"
       ],
       "optionalPeers": [
@@ -909,7 +909,7 @@
       ],
       "bin": true
     },
-    "@sveltejs/kit@2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
+    "@sveltejs/kit@2.5.24_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.56.4__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3": {
       "integrity": "sha512-Nr2oxsCsDfEkdS/zzQQQbsPYTbu692Qs3/iE3L7VHzCVjG2+WujF9oMUozWI7GuX98KxYSoPMlAsfmDLSg44hQ==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte",
@@ -924,7 +924,7 @@
         "sade",
         "set-cookie-parser",
         "sirv@2.0.4",
-        "svelte",
+        "svelte@5.56.4",
         "tiny-glob",
         "vite"
       ],
@@ -934,23 +934,23 @@
     "@sveltejs/sv-utils@0.0.2": {
       "integrity": "sha512-vmH85dvUP5UtlSgu/dmlybSUT9ZGURkrKlLNzKJ5fO5ZmnV/kzlS3UlzlTrffqbVEkaZwEJV3RW45RK19z0vVg=="
     },
-    "@sveltejs/vite-plugin-svelte-inspector@5.0.1_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.39.8___acorn@8.15.0__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3__@types+node@24.2.0_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
+    "@sveltejs/vite-plugin-svelte-inspector@5.0.1_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.56.4__vite@7.1.8___@types+node@24.2.0___picomatch@4.0.3_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3": {
       "integrity": "sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte",
         "debug",
-        "svelte",
+        "svelte@5.56.4",
         "vite"
       ]
     },
-    "@sveltejs/vite-plugin-svelte@6.2.1_svelte@5.39.8__acorn@8.15.0_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
+    "@sveltejs/vite-plugin-svelte@6.2.1_svelte@5.56.4_vite@7.1.8__@types+node@24.2.0__picomatch@4.0.3": {
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte-inspector",
         "debug",
         "deepmerge",
         "magic-string",
-        "svelte",
+        "svelte@5.56.4",
         "vite",
         "vitefu"
       ]
@@ -1069,12 +1069,15 @@
         "undici-types"
       ]
     },
-    "acorn@8.15.0": {
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+    "@types/trusted-types@2.0.7": {
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "acorn@8.17.0": {
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "bin": true
     },
-    "aria-query@5.3.2": {
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="
+    "aria-query@5.3.1": {
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="
     },
     "axobject-query@4.1.0": {
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="
@@ -1109,8 +1112,8 @@
     "detect-libc@2.1.1": {
       "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw=="
     },
-    "devalue@5.3.2": {
-      "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw=="
+    "devalue@5.8.1": {
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="
     },
     "enhanced-resolve@5.18.3": {
       "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
@@ -1155,8 +1158,8 @@
     "esm-env@1.2.2": {
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="
     },
-    "esrap@2.1.0": {
-      "integrity": "sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==",
+    "esrap@2.2.13": {
+      "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
       "dependencies": [
         "@jridgewell/sourcemap-codec"
       ]
@@ -1389,7 +1392,7 @@
       ],
       "bin": true
     },
-    "svelte-check@4.3.2_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3": {
+    "svelte-check@4.3.2_svelte@5.56.4_typescript@5.9.3": {
       "integrity": "sha512-71udP5w2kaSTcX8iV0hn3o2FWlabQHhJTJLIQrCqMsrcOeDUO2VhCQKKCA8AMVHSPwdxLEWkUWh9OKxns5PD9w==",
       "dependencies": [
         "@jridgewell/trace-mapping",
@@ -1397,21 +1400,21 @@
         "fdir",
         "picocolors",
         "sade",
-        "svelte",
+        "svelte@5.56.4",
         "typescript"
       ],
       "bin": true
     },
-    "svelte2tsx@0.7.44_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3": {
+    "svelte2tsx@0.7.44_svelte@5.56.4_typescript@5.9.3": {
       "integrity": "sha512-opuH+bCboss0/ncxnfAO+qt0IAprxc8OqwuC7otafWeO5CHjJ6UAAwvQmu/+xjpCSarX8pQKydXQuoJmbCDcTg==",
       "dependencies": [
         "dedent-js",
         "scule",
-        "svelte",
+        "svelte@5.56.4",
         "typescript"
       ]
     },
-    "svelte@5.39.8_acorn@8.15.0": {
+    "svelte@5.39.8": {
       "integrity": "sha512-KfZ3hCITdxIXTOvrea4nFZX2o+47HPTChKeocgj9BwJQYqWrviVCcPj4boXHF5yf8+eBKqhHY8xii//XaakKXA==",
       "dependencies": [
         "@jridgewell/remapping",
@@ -1422,6 +1425,27 @@
         "aria-query",
         "axobject-query",
         "clsx",
+        "esm-env",
+        "esrap",
+        "is-reference",
+        "locate-character",
+        "magic-string",
+        "zimmerframe"
+      ]
+    },
+    "svelte@5.56.4": {
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "dependencies": [
+        "@jridgewell/remapping",
+        "@jridgewell/sourcemap-codec",
+        "@sveltejs/acorn-typescript",
+        "@types/estree",
+        "@types/trusted-types",
+        "acorn",
+        "aria-query",
+        "axobject-query",
+        "clsx",
+        "devalue",
         "esm-env",
         "esrap",
         "is-reference",
@@ -1470,7 +1494,7 @@
     "ts-pattern@5.2.0": {
       "integrity": "sha512-aGaSpOlDcns7ZoeG/OMftWyQG1KqPVhgplhJxNCvyIXqWrumM5uIoOSarw/hmmi/T1PnuQ/uD8NaFHvLpHicDg=="
     },
-    "typescript-svelte-plugin@0.3.50_svelte@5.39.8__acorn@8.15.0_typescript@5.9.3": {
+    "typescript-svelte-plugin@0.3.50_svelte@5.56.4": {
       "integrity": "sha512-CD6jMNAYJwqCyQ5zZBDRuveeJvAgIogLwXMf5eXAl4K36wD8W+Npw49h6j5fXnpd7SKcG3uptGpeCGETED6WSA==",
       "dependencies": [
         "@jridgewell/sourcemap-codec",
@@ -1555,7 +1579,7 @@
             "npm:@sveltejs/vite-plugin-svelte@6.2.1",
             "npm:@tailwindcss/vite@4.1.14",
             "npm:svelte-check@4.3.2",
-            "npm:svelte@5.39.8",
+            "npm:svelte@5.56.4",
             "npm:tailwindcss@4.1.14",
             "npm:typescript-svelte-plugin@0.3.50",
             "npm:typescript@5.9.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,7 @@
 		"@sveltejs/kit": "2.43.7",
 		"@sveltejs/vite-plugin-svelte": "6.2.1",
 		"@tailwindcss/vite": "4.1.14",
-		"svelte": "5.39.8",
+		"svelte": "5.56.4",
 		"svelte-check": "4.3.2",
 		"tailwindcss": "4.1.14",
 		"typescript": "5.9.3",

--- a/packages/web/src/lib/components/TagAutoCompleteInput.svelte
+++ b/packages/web/src/lib/components/TagAutoCompleteInput.svelte
@@ -2,6 +2,7 @@
   import * as parsers from '$lib/parsers.ts'
   import type { Forager } from '@forager/core'
   import type { BaseController } from "$lib/base_controller.ts";
+  import { get_controller } from '$lib/contexts/controller.ts'
   import Tag from '$lib/components/Tag.svelte'
 
   const debounce = <Args>(fn: (...args: Args[]) => void, pause: number) => {
@@ -84,7 +85,6 @@
   type TagModel = Awaited<ReturnType<Forager['tag']['search']>>['results'][0]
 
   let {
-    controller,
     kind,
     sort_by = 'media_reference_count',
     search_string = $bindable(),
@@ -94,7 +94,6 @@
     contextual_query,
   }: {
     sort_by?: 'updated_at' | 'media_reference_count'
-    controller: BaseController
     search_string: string
     kind: 'search' | 'details'
     placeholder?: string
@@ -103,6 +102,8 @@
     // NOTE contextual_query works, but it is too slow on large tag/media_reference databases, so we need to rethink this
     contextual_query?: {}
   } = $props()
+
+  const controller = get_controller<BaseController>()
 
   let root_element: HTMLDivElement
   let input_element: HTMLInputElement

--- a/packages/web/src/lib/contexts/controller.ts
+++ b/packages/web/src/lib/contexts/controller.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'svelte'
+import type { BaseController } from '$lib/base_controller.ts'
+
+const [get_controller_context, set_controller_context] = createContext<BaseController>()
+
+/**
+ * Store the route's controller in component context so descendants can read it
+ * without prop drilling. Returns the controller for ergonomic assignment.
+ */
+function set_controller<T extends BaseController>(controller: T): T {
+  set_controller_context(controller)
+  return controller
+}
+
+/**
+ * Read the controller provided by an ancestor via {@link set_controller}. Pass
+ * the concrete controller type for the current route to narrow the return type.
+ */
+function get_controller<T extends BaseController = BaseController>(): T {
+  return get_controller_context() as T
+}
+
+export { set_controller, get_controller }

--- a/packages/web/src/routes/browse/+page.svelte
+++ b/packages/web/src/routes/browse/+page.svelte
@@ -7,27 +7,28 @@
   import Header from '$lib/components/Header.svelte'
 
   import { BrowseController } from './controller.ts'
+  import { set_controller } from '$lib/contexts/controller.ts'
 
 	/** @type {import('./$types').PageProps} */
   let props  = $props()
 
-  const controller = new BrowseController(props.data.config)
+  const controller = set_controller(new BrowseController(props.data.config))
   let { dimensions, focus, queryparams } = controller.runes
   focus.stack({component: 'BrowsePage', focus: 'page'})
 </script>
 
 <div class="h-dvh">
   <Header title={queryparams.human_readable_summary || 'Forager'} bind:height={dimensions.heights.header} >
-    <SearchParams {controller} />
+    <SearchParams />
   </Header>
   <div class="grid grid-cols-[auto_1fr]">
-    <MediaDetails {controller} />
+    <MediaDetails />
     <div class="relative">
-      <MediaView {controller} />
-      <MediaList {controller} />
+      <MediaView />
+      <MediaList />
     </div>
   </div>
-  <Footer {controller} bind:height={dimensions.heights.footer} />
+  <Footer bind:height={dimensions.heights.footer} />
 </div>
 
 <svelte:window

--- a/packages/web/src/routes/browse/components/Footer.svelte
+++ b/packages/web/src/routes/browse/components/Footer.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import * as theme from '$lib/theme.ts'
   import type { BrowseController } from '../controller.ts'
+  import { get_controller } from '$lib/contexts/controller.ts'
 
-  let {controller, height = $bindable()}: {controller: BrowseController, height: number} = $props()
+  let {height = $bindable()}: {height: number} = $props()
+  const controller = get_controller<BrowseController>()
 
 
   function human_readable_number(n: number) {

--- a/packages/web/src/routes/browse/components/MediaDetailEntry.svelte
+++ b/packages/web/src/routes/browse/components/MediaDetailEntry.svelte
@@ -2,9 +2,7 @@
   import * as datetime from '@std/datetime'
   import type { Json } from '@andykais/ts-rpc/adapters/sveltekit.ts'
 
-  import { BrowseController } from '../controller.ts'
-  let {controller, ...props}: {
-    controller: BrowseController
+  let props: {
     label: string
     content: string | number | Date | null | Json
     type?: "text" | "datetime-local"

--- a/packages/web/src/routes/browse/components/MediaDetails.svelte
+++ b/packages/web/src/routes/browse/components/MediaDetails.svelte
@@ -11,7 +11,9 @@
   import * as parsers from '$lib/parsers.ts'
 
   import { BrowseController } from '../controller.ts'
-  let {controller}: {controller: BrowseController} = $props()
+  import { get_controller } from '$lib/contexts/controller.ts'
+
+  const controller = get_controller<BrowseController>()
   let {dimensions, media_selections, settings, queryparams} = controller.runes
 
   let new_tag_str = $state<string>('')
@@ -74,14 +76,10 @@
     }}
     >
     {#if media_selections.current_selection.media_response}
-      <MediaDetailEntry
-        {controller}
-        label="Views"
+      <MediaDetailEntry        label="Views"
         content={media_selections.current_selection.media_response.media_reference.view_count}/>
 
-      <MediaDetailEntry
-        {controller}
-        label="Stars"
+      <MediaDetailEntry        label="Stars"
         content={media_selections.current_selection.media_response.media_reference.stars}/>
 
       <label class="text-green-50" for="tags"><span>Tags</span></label>
@@ -104,24 +102,18 @@
             </button>
             <SearchLink
               class="hover:cursor-pointer"
-              title="Apply to search"
-              {controller}
-              params={queryparams.merge({tags: parsers.Tag.encode(tag)})}>
+              title="Apply to search"              params={queryparams.merge({tags: parsers.Tag.encode(tag)})}>
               <Icon class="fill-green-50 hover:fill-green-300" data={MagnifyingGlassPlus} size="20px" color="none" />
             </SearchLink>
             <SearchLink
               class="hover:cursor-pointer"
-              title="Start new search"
-              {controller}
-              params={{...queryparams.DEFAULTS, search_string: parsers.Tag.encode(tag)}}>
+              title="Start new search"              params={{...queryparams.DEFAULTS, search_string: parsers.Tag.encode(tag)}}>
               <Icon class="fill-green-50 hover:fill-green-300" data={ArrowTopRightOnSquare} size="20px" color="none" />
             </SearchLink>
           </div>
         {/each}
       {/each}
-      <TagAutoCompleteInput
-        {controller}
-        sort_by="updated_at"
+      <TagAutoCompleteInput        sort_by="updated_at"
         bind:search_string={new_tag_str}
         placeholder=""
         kind="details"
@@ -129,57 +121,41 @@
       />
       <input type="submit" class='hidden'>
 
-      <MediaDetailEntry
-        {controller}
-        editable
+      <MediaDetailEntry        editable
         hide_if_null
         label="Title"
         content={media_selections.current_selection.media_response.media_reference.title}/>
 
-      <MediaDetailEntry
-        {controller}
-        editable
+      <MediaDetailEntry        editable
         hide_if_null
         label="Description"
         content={media_selections.current_selection.media_response.media_reference.description}/>
 
-      <MediaDetailEntry
-        {controller}
-        editable
+      <MediaDetailEntry        editable
         hide_if_null
         label="Created"
         type="datetime-local"
         content={media_selections.current_selection.media_response.media_reference.source_created_at}/>
 
       <!-- TODO we should support datetimes in @andykais/ts-rpc -->
-      <MediaDetailEntry
-        {controller}
-        editable
+      <MediaDetailEntry        editable
         label="Added"
         type="datetime-local"
         content={media_selections.current_selection.media_response.media_reference.created_at}/>
 
-      <MediaDetailEntry
-        {controller}
-        hide_if_null
+      <MediaDetailEntry        hide_if_null
         label="Source URL"
         content={media_selections.current_selection.media_response.media_reference.source_url}/>
 
-      <MediaDetailEntry
-        {controller}
-        hide_if_null
+      <MediaDetailEntry        hide_if_null
         label="Metadata"
         content={media_selections.current_selection.media_response.media_reference.metadata}/>
 
       {#if media_selections.current_selection.media_response.media_type === 'media_file'}
-        <MediaDetailEntry
-          {controller}
-          label="File"
+        <MediaDetailEntry          label="File"
           content={media_selections.current_selection.media_response.media_file.filepath}/>
 
-        <MediaDetailEntry
-          {controller}
-          label="Filename"
+        <MediaDetailEntry          label="Filename"
           content={path.basename(media_selections.current_selection.media_response.media_file.filepath)}/>
       {/if}
 

--- a/packages/web/src/routes/browse/components/MediaList.svelte
+++ b/packages/web/src/routes/browse/components/MediaList.svelte
@@ -2,8 +2,9 @@
   import Scroller from '$lib/components/Scroller.svelte'
   import SearchResults from './SearchResults.svelte'
   import type { BrowseController } from '../controller.ts'
+  import { get_controller } from '$lib/contexts/controller.ts'
 
-  let {controller}: {controller: BrowseController} = $props()
+  const controller = get_controller<BrowseController>()
   let media_list_element: HTMLElement
 
   controller.keybinds.component_listen({
@@ -54,6 +55,6 @@
     ]}
     style="height: {controller.runes.dimensions.heights.media_list}px"
   >
-    <SearchResults {controller} />
+    <SearchResults />
   </Scroller>
 </div>

--- a/packages/web/src/routes/browse/components/MediaView.svelte
+++ b/packages/web/src/routes/browse/components/MediaView.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import type { BrowseController } from '../controller.ts'
-
-  interface Props {
-    controller: BrowseController
-  }
+  import { get_controller } from '$lib/contexts/controller.ts'
 
   // TODO wire this into settings
   let show_controls = $state<boolean>(false);
@@ -13,7 +10,7 @@
     is_fullscreen = document.fullscreenElement === fullscreen_container
   }
 
-  let {controller}: Props = $props()
+  const controller = get_controller<BrowseController>()
   let paused = $state(false)
 
   const media_fit_classes = $derived.by(() => {

--- a/packages/web/src/routes/browse/components/SearchLink.svelte
+++ b/packages/web/src/routes/browse/components/SearchLink.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
   import type {BrowseController} from '../controller.ts'
   import type { SvelteHTMLElements, ClassValue } from 'svelte/elements';
+  import { get_controller } from '$lib/contexts/controller.ts'
 
   interface Props {
-    controller: BrowseController
     params: Partial<BrowseController['runes']['queryparams']['DEFAULTS']>
     class?: ClassValue
     title?: string
     children: SvelteHTMLElements['div']['children']
   }
-  let {params, controller, children, ...props}: Props = $props()
-  const {queryparams} = controller.runes
-
-  console.log({params})
-
+  let {params, children, ...props}: Props = $props()
+  const {queryparams} = get_controller<BrowseController>().runes
 </script>
 
 <a

--- a/packages/web/src/routes/browse/components/SearchParams.svelte
+++ b/packages/web/src/routes/browse/components/SearchParams.svelte
@@ -5,10 +5,10 @@
   import { Filter, ChevronUp, ChevronDown, ArrowDown, ArrowUp } from '$lib/icons/mod.ts'
   import TagAutoCompleteInput from "$lib/components/TagAutoCompleteInput.svelte";
   import type { BrowseController } from "../controller.ts";
+  import { get_controller } from '$lib/contexts/controller.ts'
   import StarInput from '$lib/components/StarInput.svelte'
 
-  let {controller}: {controller: BrowseController} = $props()
-
+  const controller = get_controller<BrowseController>()
   const {queryparams, media_selections, settings} = controller.runes
 
   async function update_search() {
@@ -28,7 +28,6 @@
   <div class="flex gap-2 p-3 justify-center items-center w-full">
     <div class="w-full grid grid-cols-[1fr_auto] gap-2">
       <TagAutoCompleteInput
-        {controller}
         bind:search_string={queryparams.draft.search_string}
         contextual_query={queryparams.contextual_query}
         kind="search"

--- a/packages/web/src/routes/browse/components/SearchResults.svelte
+++ b/packages/web/src/routes/browse/components/SearchResults.svelte
@@ -5,12 +5,9 @@
   import Icon from '$lib/components/Icon.svelte'
   import SearchLink from './SearchLink.svelte'
   import * as icons from '$lib/icons/mod.ts'
+  import { get_controller } from '$lib/contexts/controller.ts'
 
-  interface Props {
-    controller: BrowseController
-  }
-
-  let {controller}: Props = $props()
+  const controller = get_controller<BrowseController>()
   const {queryparams, settings, media_selections, media_list} = controller.runes
 
   let tile_size = settings.ui.media_list.thumbnail_size
@@ -130,7 +127,7 @@
               <Icon data={icons.Copy} fill={icon_color} stroke="none" size={icon_size} />
               <SearchLink
                 class="hover:text-green-500 hover:bg-gray-700 px-2 rounded-sm"
-                {controller} params={queryparams.merge({mode: 'media', tags: `${queryparams.current.group_by ?? ''}:${result.group_metadata.value}`})}> {result.group_metadata.value} 
+                params={queryparams.merge({mode: 'media', tags: `${queryparams.current.group_by ?? ''}:${result.group_metadata.value}`})}> {result.group_metadata.value} 
               </SearchLink>
               <span>{result.group_metadata.count}</span>
           {:else}

--- a/packages/web/src/routes/tags/+page.svelte
+++ b/packages/web/src/routes/tags/+page.svelte
@@ -3,19 +3,20 @@
   import TagSearchResults from './components/TagSearchResults.svelte'
   import Footer from './components/Footer.svelte'
   import { TagsController } from './controller.ts'
+  import { set_controller } from '$lib/contexts/controller.ts'
   import Header from '$lib/components/Header.svelte'
 
 	/** @type {import('./$types').PageProps} */
   let props = $props()
-  const controller = new TagsController(props.data.config)
+  set_controller(new TagsController(props.data.config))
 </script>
 
 <div class="h-dvh flex flex-col">
   <Header title="Tag Search">
-    <TagSearchParams {controller} />
+    <TagSearchParams />
   </Header>
   <div class="flex-grow overflow-y-auto">
-    <TagSearchResults {controller} />
+    <TagSearchResults />
   </div>
-  <Footer {controller} />
+  <Footer />
 </div>

--- a/packages/web/src/routes/tags/[slug]/+page.svelte
+++ b/packages/web/src/routes/tags/[slug]/+page.svelte
@@ -7,10 +7,11 @@
   import { XCircle, ArrowTopRightOnSquare } from '$lib/icons/mod.ts'
   import TagAutoCompleteInput from '$lib/components/TagAutoCompleteInput.svelte'
   import { TagDetailController } from './controller.svelte.ts'
+  import { set_controller } from '$lib/contexts/controller.ts'
   import Numeric from '$lib/components/Numeric.svelte';
 
   let props = $props()
-  const controller = new TagDetailController(props.data.config)
+  const controller = set_controller(new TagDetailController(props.data.config))
 
   let alias_input = $state('')
   let child_input = $state('')
@@ -150,7 +151,6 @@
             <div class="flex-grow">
               <label class="text-slate-400 text-xs">Set this tag as an alias that hides the following tags:</label>
               <TagAutoCompleteInput
-                {controller}
                 bind:search_string={alias_input}
                 kind="details"
                 placeholder="set alias for this tag..."
@@ -200,7 +200,6 @@
             }}>
               <div class="flex-grow">
                 <TagAutoCompleteInput
-                  {controller}
                   bind:search_string={parent_input}
                   kind="details"
                   placeholder="add parent tag..."
@@ -246,7 +245,6 @@
             }}>
               <div class="flex-grow">
                 <TagAutoCompleteInput
-                  {controller}
                   bind:search_string={child_input}
                   kind="details"
                   placeholder="add child tag..."

--- a/packages/web/src/routes/tags/components/Footer.svelte
+++ b/packages/web/src/routes/tags/components/Footer.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { TagsController } from '../controller.ts'
+  import { get_controller } from '$lib/contexts/controller.ts'
 
-  let { controller }: { controller: TagsController } = $props()
-  const { queryparams } = controller.runes
+  const { queryparams } = get_controller<TagsController>().runes
 
   function human_readable_number(n: number) {
     const number_string = n.toString()

--- a/packages/web/src/routes/tags/components/TagSearchParams.svelte
+++ b/packages/web/src/routes/tags/components/TagSearchParams.svelte
@@ -3,9 +3,9 @@
   import { ArrowDown, ArrowUp } from '$lib/icons/mod.ts'
   import * as theme from '$lib/theme.ts'
   import type { TagsController } from '../controller.ts'
+  import { get_controller } from '$lib/contexts/controller.ts'
 
-  let { controller }: { controller: TagsController } = $props()
-  const { queryparams } = controller.runes
+  const { queryparams } = get_controller<TagsController>().runes
 
   const icon_color = theme.colors.gray[800]
   const icon_size = '22px'

--- a/packages/web/src/routes/tags/components/TagSearchResults.svelte
+++ b/packages/web/src/routes/tags/components/TagSearchResults.svelte
@@ -5,9 +5,9 @@
   import type { TagsController } from '../controller.ts'
   import { goto } from '$app/navigation';
   import Numeric from '$lib/components/Numeric.svelte';
+  import { get_controller } from '$lib/contexts/controller.ts'
 
-  let { controller }: { controller: TagsController } = $props()
-  const { queryparams } = controller.runes
+  const { queryparams } = get_controller<TagsController>().runes
 
   type SortBy = typeof queryparams.draft.sort_by
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- implements a typed `$lib/contexts/controller` helper built on svelte's `createContext` (`set_controller` / `get_controller<T>()`)
- improves the browse and tags routes by setting the route controller in component context at the page root instead of passing a `controller` prop through every child
- removes all `controller` prop drilling (18+ static prop passes across the browse tree, plus the tags routes); descendants now read the controller via `get_controller()`
- drops the unused `controller` prop from `MediaDetailEntry` and a leftover debug `console.log` in `SearchLink`
- bumps `svelte` `5.39.8` -> `5.56.4`, since `createContext` was added in svelte 5.40

## Vision Testing

- `deno task --cwd packages/web build` succeeds
- `deno task --cwd packages/web check` reports an identical per-file error distribution before and after the change (131 pre-existing errors, 0 introduced)
- manually verified the browse UI (search, advanced filters, thumbnail selection, media detail sidebar, tag autocomplete, footer controls) and the tags list + tag detail pages render and behave correctly with the controller sourced from context

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066f8828-3c4c-437a-a4bd-8a496d23f3ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066f8828-3c4c-437a-a4bd-8a496d23f3ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

